### PR TITLE
Adding GetExecutionState and Adhoc support

### DIFF
--- a/src/rundeck.v12/adhoc.go
+++ b/src/rundeck.v12/adhoc.go
@@ -1,0 +1,24 @@
+package rundeck
+
+import (
+	"strings"
+)
+
+type ExecutionId struct {
+	ID string `xml:"id,attr"`
+}
+
+func (c *RundeckClient) RunAdhoc(projectId string, exec string, node_filter string) (ExecutionId, error) {
+	options := make(map[string]string)
+	options["project"] = projectId
+	options["exec"] = exec
+	n := strings.Split(node_filter, " ")
+	for _, i := range n {
+		f := strings.Split(i, "=")
+		k, v := f[0], f[1]
+		options[k] = v
+	}
+	var data ExecutionId
+	err := c.Get(&data, "run/command", options)
+	return data, err
+}

--- a/src/rundeck.v12/assets/test/execution.xml
+++ b/src/rundeck.v12/assets/test/execution.xml
@@ -1,0 +1,17 @@
+<output>
+	<id>23</id>
+	<offset>424</offset>
+	<completed>true</completed>
+	<execCompleted>true</execCompleted>
+	<hasFailedNodes>false</hasFailedNodes>
+	<execState>succeeded</execState>
+	<lastModified>1433212362000</lastModified>
+	<execDuration>409</execDuration>
+	<percentLoaded>98.6046511627907</percentLoaded>
+	<totalSize>430</totalSize>
+	<entries>
+		<entry time='02:32:42' absolute_time='2015-06-02T02:32:42Z' log='hello' level='NORMAL' user='rundeck' command='' stepctx='1' node='localhost' />
+		<entry time='02:33:42' absolute_time='2015-06-02T02:33:42Z' log='bye' level='NORMAL' user='rundeck' command='' stepctx='1' node='localhost' />
+	</entries>
+</output>
+

--- a/src/rundeck.v12/execution.go
+++ b/src/rundeck.v12/execution.go
@@ -1,0 +1,47 @@
+package rundeck
+
+import "encoding/xml"
+
+type ExecutionOutput struct {
+	XMLName        xml.Name               `xml:"output"`
+	ID             int64                  `xml:"id"`
+	Offset         int64                  `xml:"offset"`
+	Completed      bool                   `xml:"completed"`
+	ExecCompleted  bool                   `xml:"execCompleted"`
+	HasFailedNodes bool                   `xml:"hasFailedNodes"`
+	ExecState      string                 `xml:"execState"`
+	LastModified   ExecutionDateTime      `xml:"lastModified"`
+	ExecDuration   int64                  `xml:"execDuration"`
+	TotalSize      int64                  `xml:"totalSize"`
+	Entries        ExecutionOutputEntries `xml:"entries"`
+}
+
+type ExecutionOutputEntries struct {
+	Entry []ExecutionOutputEntry `xml:"entry"`
+}
+
+type ExecutionOutputEntry struct {
+	XMLName      xml.Name
+	Time         string `xml:"time,attr"`
+	AbsoluteTime string `xml:"absolute_time,attr"`
+	Log          string `xml:"log,attr"`
+	Level        string `xml:"level,attr"`
+	User         string `xml:"user,attr"`
+	Command      string `xml:"command,attr"`
+	Stepctx      string `xml:"stepctx,attr"`
+	Node         string `xml:"node,attr"`
+}
+
+func (c *RundeckClient) GetExecutionState(executionId string) (ExecutionState, error) {
+	u := make(map[string]string)
+	var data ExecutionState
+	err := c.Get(&data, "execution/"+executionId+"/state", u)
+	return data, err
+}
+
+func (c *RundeckClient) GetExecutionOutput(executionId string) (ExecutionOutput, error) {
+	u := make(map[string]string)
+	var data ExecutionOutput
+	err := c.Get(&data, "execution/"+executionId+"/output", u)
+	return data, err
+}

--- a/src/rundeck.v12/execution_test.go
+++ b/src/rundeck.v12/execution_test.go
@@ -1,0 +1,27 @@
+package rundeck
+
+import (
+	"encoding/xml"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestExecutionOutput(t *testing.T) {
+	xmlfile, err := os.Open("assets/test/execution.xml")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer xmlfile.Close()
+	xmlData, _ := ioutil.ReadAll(xmlfile)
+	var s ExecutionOutput
+	xml.Unmarshal(xmlData, &s)
+
+	intexpects(s.ID, 23, t)
+	intexpects(s.Offset, 424, t)
+	strexpects(s.ExecState, "succeeded", t)
+	intexpects(s.ExecDuration, 409, t)
+	intexpects(s.TotalSize, 430, t)
+	strexpects(s.Entries.Entry[0].Log, "hello", t)
+	strexpects(s.Entries.Entry[1].Log, "bye", t)
+}


### PR DESCRIPTION
This adds the ability to get the execution state and output of a job and the ability to run adhoc commands.

Also, I'm using go-rundeck as a library at https://github.com/paulhamby/rundeck-client. I wanted to have a single binary with multiple sub-commands. If you like this approach, I'd be happy to combine our efforts by making a separate PR to your repo. It's totally cool if not, just wanted to make sure you are cool with me "borrowing" a lot of your code.

Thanks for making this code available!