### PR TITLE
feat(execution): Add aborting executions endpoint

### DIFF
--- a/src/rundeck.v17/execution.go
+++ b/src/rundeck.v17/execution.go
@@ -68,6 +68,17 @@ type ExecutionState struct {
 	Nodes       []NodeWithSteps `xml:"executionState>nodes>node"`
 }
 
+type ExecutionAbort struct {
+	XMLName   xml.Name `xml:"abort"`
+	Status    string   `xml:"status,attr"`
+	Execution struct {
+		HRef      string `xml:"href,attr"`
+		Permalink string `xml:"permalink,attr"`
+		ID        string `xml:"id,attr"`
+		Status    string `xml:"status,attr"`
+	} `xml:"execution"`
+}
+
 func (c *RundeckClient) GetExecution(executionId string) (exec Execution, err error) {
 	var res []byte
 	var execs Executions
@@ -99,4 +110,17 @@ func (c *RundeckClient) GetExecutionOutput(executionId string) (ExecutionOutput,
 
 func (c *RundeckClient) DeleteExecution(id string) error {
 	return c.Delete("execution/"+id, nil)
+}
+
+func (c *RundeckClient) AbortExecution(id string) (ExecutionAbort, error) {
+	var res []byte
+	var exec ExecutionAbort
+	err := c.Get(&res, "execution/"+id+"/abort", nil)
+	if err != nil {
+		return exec, err
+	}
+	if xmlerr := xml.Unmarshal(res, &exec); xmlerr != nil {
+		return exec, xmlerr
+	}
+	return exec, nil
 }


### PR DESCRIPTION
Abort a running execution by ID.

> GET /api/1/execution/[ID]/abort

http://rundeck.org/docs/api/#aborting-executions

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lusis/go-rundeck/13)
<!-- Reviewable:end -->
