### PR TITLE
Versioned responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ else
 	GOPATH := $(GOPATH):$(TRAVIS_BUILD_DIR)
 endif
 
-all: clean test $(BINLIST)
+all: clean bindata test $(BINLIST)
 
 test:
 	@script/test
@@ -34,4 +34,4 @@ $(BINLIST):
 clean:
 	@rm -rf bin/
 
-.PHONY: all clean test $(BINLIST)
+.PHONY: all clean bindata test $(BINLIST)

--- a/cmd/rundeck/cmds/get_tokens.go
+++ b/cmd/rundeck/cmds/get_tokens.go
@@ -33,7 +33,8 @@ func getTokensFunc(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		for _, d := range data {
+
+		for _, d := range *data {
 			if rowErr := cli.OutputFormatter.AddRow([]string{
 				d.ID,
 				d.User,

--- a/pkg/rundeck/acl_policy.go
+++ b/pkg/rundeck/acl_policy.go
@@ -16,7 +16,7 @@ type ACLPolicies responses.ACLResponse
 // ListSystemACLPolicies gets the system ACL Policies
 // http://rundeck.org/docs/api/index.html#list-system-acl-policies
 func (c *Client) ListSystemACLPolicies() (*ACLPolicies, error) {
-	if _, err := c.hasRequiredAPIVersion(14, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ACLResponse{}); err != nil {
 		return nil, err
 	}
 	data := &ACLPolicies{}
@@ -33,7 +33,7 @@ func (c *Client) ListSystemACLPolicies() (*ACLPolicies, error) {
 // GetSystemACLPolicy returns the named acl policy
 // http://rundeck.org/docs/api/index.html#get-an-acl-policy
 func (c *Client) GetSystemACLPolicy(policy string) ([]byte, error) {
-	if _, err := c.hasRequiredAPIVersion(14, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ACLResponse{}); err != nil {
 		return nil, err
 	}
 	url := fmt.Sprintf("system/acl/%s.aclpolicy", policy)
@@ -47,7 +47,7 @@ func (c *Client) GetSystemACLPolicy(policy string) ([]byte, error) {
 // CreateSystemACLPolicy creates a system acl policy
 // http://rundeck.org/docs/api/index.html#create-an-acl-policy
 func (c *Client) CreateSystemACLPolicy(name string, contents io.Reader) error {
-	if _, err := c.hasRequiredAPIVersion(14, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ACLResponse{}); err != nil {
 		return err
 	}
 	url := fmt.Sprintf("system/acl/%s.aclpolicy", name)
@@ -81,7 +81,7 @@ func (c *Client) CreateSystemACLPolicy(name string, contents io.Reader) error {
 // UpdateSystemACLPolicy creates a system acl policy
 // http://rundeck.org/docs/api/index.html#update-an-acl-policy
 func (c *Client) UpdateSystemACLPolicy(name string, contents io.Reader) error {
-	if _, err := c.hasRequiredAPIVersion(14, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ACLResponse{}); err != nil {
 		return err
 	}
 	url := fmt.Sprintf("system/acl/%s.aclpolicy", name)
@@ -106,7 +106,7 @@ func (c *Client) UpdateSystemACLPolicy(name string, contents io.Reader) error {
 // DeleteSystemACLPolicy deletes a system ACL Policy
 // http://rundeck.org/docs/api/index.html#delete-an-acl-policy
 func (c *Client) DeleteSystemACLPolicy(name string) error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ACLResponse{}); err != nil {
 		return err
 	}
 	return c.httpDelete("system/acl/"+name+".aclpolicy", requestJSON(), requestExpects(204))
@@ -115,7 +115,7 @@ func (c *Client) DeleteSystemACLPolicy(name string) error {
 // ListProjectACLPolicies gets a project ACL Policies
 // http://rundeck.org/docs/api/index.html#list-project-acl-policies
 func (c *Client) ListProjectACLPolicies(name string) error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ACLResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -124,7 +124,7 @@ func (c *Client) ListProjectACLPolicies(name string) error {
 // GetProjectACLPolicy gets a project ACL Policy
 // http://rundeck.org/docs/api/index.html#get-a-project-acl-policy
 func (c *Client) GetProjectACLPolicy(name string) error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ACLResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -133,7 +133,7 @@ func (c *Client) GetProjectACLPolicy(name string) error {
 // DeleteProjectACLPolicy deletes a project ACL Policy
 // http://rundeck.org/docs/api/index.html#delete-a-project-acl-policy
 func (c *Client) DeleteProjectACLPolicy(name string) error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ACLResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -142,7 +142,7 @@ func (c *Client) DeleteProjectACLPolicy(name string) error {
 // CreateProjectACLPolicy creates a project ACL Policy
 // http://rundeck.org/docs/api/index.html#create-a-project-acl-policy
 func (c *Client) CreateProjectACLPolicy(name string) error {
-	if _, err := c.hasRequiredAPIVersion(14, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ACLResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -151,7 +151,7 @@ func (c *Client) CreateProjectACLPolicy(name string) error {
 // UpdateProjectACLPolicy updates a project ACL Policy
 // http://rundeck.org/docs/api/index.html#update-a-project-acl-policy
 func (c *Client) UpdateProjectACLPolicy(name string) error {
-	if _, err := c.hasRequiredAPIVersion(14, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ACLResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")

--- a/pkg/rundeck/adhoc.go
+++ b/pkg/rundeck/adhoc.go
@@ -51,7 +51,7 @@ func CmdKeepGoing() AdHocRunOption {
 // RunAdHocCommand runs an adhoc job - all nodes by default
 // http://rundeck.org/docs/api/index.html#running-adhoc-commands
 func (c *Client) RunAdHocCommand(projectID string, exec string, opts ...AdHocRunOption) (*AdHocExecution, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.AdHocExecutionResponse{}); err != nil {
 		return nil, err
 	}
 	data := &AdHocExecution{}
@@ -80,7 +80,7 @@ func (c *Client) RunAdHocCommand(projectID string, exec string, opts ...AdHocRun
 // RunAdHocScript runs a script ad-hoc
 // http://rundeck.org/docs/api/index.html#running-adhoc-scripts
 func (c *Client) RunAdHocScript() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.AdHocExecutionResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -89,7 +89,7 @@ func (c *Client) RunAdHocScript() error {
 // RunAdHocScriptFromURL runs a script ad-hoc from a url
 // http://rundeck.org/docs/api/index.html#running-adhoc-script-urls
 func (c *Client) RunAdHocScriptFromURL() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.AdHocExecutionResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")

--- a/pkg/rundeck/client.go
+++ b/pkg/rundeck/client.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"os"
+	"strconv"
 
 	"golang.org/x/net/publicsuffix"
 )
@@ -67,6 +68,14 @@ func clientConfigFrom(from string) (*ClientConfig, error) {
 		if os.Getenv("RUNDECK_VERSION") == "" {
 			config.APIVersion = MaxRundeckVersion
 		} else {
+			ver := os.Getenv("RUNDECK_VERSION")
+			intVer, intverErr := strconv.Atoi(ver)
+			if intverErr != nil {
+				return nil, intverErr
+			}
+			if intVer < minJSONSupportedAPIVersion {
+				return nil, fmt.Errorf("minimum api version supported is %d", minJSONSupportedAPIVersion)
+			}
 			config.APIVersion = os.Getenv("RUNDECK_VERSION")
 		}
 

--- a/pkg/rundeck/constants.go
+++ b/pkg/rundeck/constants.go
@@ -10,9 +10,6 @@ const MaxRundeckVersion = "21"
 // minimum version of rundeck api version that supports json
 const minJSONSupportedAPIVersion = 14
 
-// int version of MaxRundeckVersion because I'm lazy
-const maxRundeckVersionInt = 21
-
 const (
 	basicAuthType = "basic"
 )

--- a/pkg/rundeck/execution.go
+++ b/pkg/rundeck/execution.go
@@ -17,7 +17,7 @@ type ExecutionState responses.ExecutionStateResponse
 // GetExecutionInfo returns the details of a job execution
 // http://rundeck.org/docs/api/index.html#execution-info
 func (c *Client) GetExecutionInfo(executionID string) (*Execution, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ExecutionResponse{}); err != nil {
 		return nil, err
 	}
 	exec := &Execution{}
@@ -34,7 +34,7 @@ func (c *Client) GetExecutionInfo(executionID string) (*Execution, error) {
 // GetExecutionState returns the state of an execution
 // http://rundeck.org/docs/api/index.html#execution-state
 func (c *Client) GetExecutionState(executionID string) (*ExecutionState, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ExecutionStateResponse{}); err != nil {
 		return nil, err
 	}
 	data := &ExecutionState{}
@@ -51,7 +51,7 @@ func (c *Client) GetExecutionState(executionID string) (*ExecutionState, error) 
 // GetExecutionOutput returns the output of an execution
 // http://rundeck.org/docs/api/index.html#execution-output
 func (c *Client) GetExecutionOutput(executionID string) ([]byte, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.GenericVersionedResponse{}); err != nil {
 		return nil, err
 	}
 	return c.httpGet("execution/"+executionID+"/output", accept("text/plain"), requestExpects(200))
@@ -60,7 +60,7 @@ func (c *Client) GetExecutionOutput(executionID string) ([]byte, error) {
 // DeleteExecution deletes an execution
 // http://rundeck.org/docs/api/index.html#delete-an-execution
 func (c *Client) DeleteExecution(id string) error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.GenericVersionedResponse{}); err != nil {
 		return err
 	}
 	return c.httpDelete("execution/"+id, requestJSON(), requestExpects(204))
@@ -69,7 +69,7 @@ func (c *Client) DeleteExecution(id string) error {
 // DisableExecution disables an execution
 // http://rundeck.org/docs/api/index.html#disable-executions-for-a-job
 func (c *Client) DisableExecution(id string) (bool, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ToggleResponse{}); err != nil {
 		return false, err
 	}
 	t := &responses.ToggleResponse{}
@@ -86,7 +86,7 @@ func (c *Client) DisableExecution(id string) (bool, error) {
 // EnableExecution enables an execution
 // http://rundeck.org/docs/api/index.html#enable-executions-for-a-job
 func (c *Client) EnableExecution(id string) (bool, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ToggleResponse{}); err != nil {
 		return false, err
 	}
 	t := &responses.ToggleResponse{}
@@ -103,7 +103,7 @@ func (c *Client) EnableExecution(id string) (bool, error) {
 // ListInputFilesForExecution lists input files used for an execution
 // http://rundeck.org/docs/api/index.html#list-input-files-for-an-execution
 func (c *Client) ListInputFilesForExecution() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ExecutionInputFilesResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -112,7 +112,7 @@ func (c *Client) ListInputFilesForExecution() error {
 // AbortExecution lists input files used for an execution
 // http://rundeck.org/docs/api/index.html#aborting-executions
 func (c *Client) AbortExecution() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.AbortExecutionResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")

--- a/pkg/rundeck/executions.go
+++ b/pkg/rundeck/executions.go
@@ -20,6 +20,9 @@ type DeletedExecutions responses.BulkDeleteExecutionsResponse
 // ListProjectExecutions lists a projects executions
 // http://rundeck.org/docs/api/index.html#execution-query
 func (c *Client) ListProjectExecutions(projectID string, options map[string]string) (*Executions, error) {
+	if err := c.checkRequiredAPIVersion(responses.ListRunningExecutionsResponse{}); err != nil {
+		return nil, err
+	}
 	data := &Executions{}
 	res, err := c.httpGet("project/"+projectID+"/executions",
 		requestJSON(),
@@ -37,7 +40,7 @@ func (c *Client) ListProjectExecutions(projectID string, options map[string]stri
 // ListRunningExecutions lists running executions
 // http://rundeck.org/docs/api/index.html#listing-running-executions
 func (c *Client) ListRunningExecutions(projectID string) (*Executions, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ListRunningExecutionsResponse{}); err != nil {
 		return nil, err
 	}
 	options := make(map[string]string)
@@ -58,6 +61,9 @@ func (c *Client) ListRunningExecutions(projectID string) (*Executions, error) {
 // BulkDeleteExecutions deletes a list of executions by id
 // http://rundeck.org/docs/api/index.html#bulk-delete-executions
 func (c *Client) BulkDeleteExecutions(ids ...int) (*DeletedExecutions, error) {
+	if err := c.checkRequiredAPIVersion(responses.BulkDeleteExecutionsResponse{}); err != nil {
+		return nil, err
+	}
 	data := &DeletedExecutions{}
 	opts := make(map[string]string)
 
@@ -83,7 +89,7 @@ func (c *Client) BulkDeleteExecutions(ids ...int) (*DeletedExecutions, error) {
 // BulkEnableExecution enables job execution in bulk
 // http://rundeck.org/docs/api/index.html#bulk-toggle-job-execution
 func (c *Client) BulkEnableExecution(ids ...string) (*responses.BulkToggleResponse, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.BulkToggleResponse{}); err != nil {
 		return nil, err
 	}
 	req := &requests.BulkToggleRequest{
@@ -107,7 +113,7 @@ func (c *Client) BulkEnableExecution(ids ...string) (*responses.BulkToggleRespon
 // BulkDisableExecution disables job execution in bulk
 // http://rundeck.org/docs/api/index.html#bulk-toggle-job-execution
 func (c *Client) BulkDisableExecution(ids ...string) (*responses.BulkToggleResponse, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.BulkToggleResponse{}); err != nil {
 		return nil, err
 	}
 	req := &requests.BulkToggleRequest{

--- a/pkg/rundeck/history.go
+++ b/pkg/rundeck/history.go
@@ -14,7 +14,9 @@ type History responses.HistoryResponse
 // ListHistory returns the history for a project
 // http://rundeck.org/docs/api/index.html#listing-history
 func (c *Client) ListHistory(project string, opts ...map[string]string) (*History, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.HistoryResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.HistoryResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return nil, err
 	}
 	u := make(map[string]string)

--- a/pkg/rundeck/history.go
+++ b/pkg/rundeck/history.go
@@ -14,9 +14,7 @@ type History responses.HistoryResponse
 // ListHistory returns the history for a project
 // http://rundeck.org/docs/api/index.html#listing-history
 func (c *Client) ListHistory(project string, opts ...map[string]string) (*History, error) {
-	minVer := responses.GetMinVersionFor(responses.HistoryResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.HistoryResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.HistoryResponse{}); err != nil {
 		return nil, err
 	}
 	u := make(map[string]string)

--- a/pkg/rundeck/job.go
+++ b/pkg/rundeck/job.go
@@ -85,7 +85,7 @@ func RunJobRunAt(t time.Time) RunJobOption {
 // GetJobMetaData gets a job's metadata
 // http://rundeck.org/docs/api/index.html#get-job-metadata
 func (c *Client) GetJobMetaData(id string) (*JobMetaData, error) {
-	if _, err := c.hasRequiredAPIVersion(18, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.JobMetaDataResponse{}); err != nil {
 		return nil, err
 	}
 	data := &JobMetaData{}
@@ -102,7 +102,7 @@ func (c *Client) GetJobMetaData(id string) (*JobMetaData, error) {
 // GetJobDefinition gets a job definition
 // http://rundeck.org/docs/api/index.html#getting-a-job-definition
 func (c *Client) GetJobDefinition(id string, format string) ([]byte, error) {
-	if _, err := c.hasRequiredAPIVersion(14, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.JobYAMLResponse{}); err != nil {
 		return nil, err
 	}
 	options := []httpclient.RequestOption{
@@ -128,7 +128,7 @@ func (c *Client) GetJobInfo(id string) (*JobMetaData, error) {
 // DeleteJob deletes a job
 // http://rundeck.org/docs/api/index.html#deleting-a-job-definition
 func (c *Client) DeleteJob(id string) error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.GenericVersionedResponse{}); err != nil {
 		return err
 	}
 	return c.httpDelete("job/"+id, httpclient.ExpectStatus(204))
@@ -138,7 +138,7 @@ func (c *Client) DeleteJob(id string) error {
 // ExportJob exports a job
 // http://rundeck.org/docs/api/index.html#exporting-jobs
 func (c *Client) ExportJob(id string, format string) ([]byte, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.JobYAMLResponse{}); err != nil {
 		return nil, err
 	}
 	if format != "xml" && format != "yaml" {
@@ -157,7 +157,7 @@ func (c *Client) ExportJob(id string, format string) ([]byte, error) {
 // RunJob runs a job
 // http://rundeck.org/docs/api/index.html#running-a-job
 func (c *Client) RunJob(id string, opts ...RunJobOption) (*Execution, error) {
-	if _, err := c.hasRequiredAPIVersion(18, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ExecutionResponse{}); err != nil {
 		return nil, err
 	}
 	jobOpts := &requests.RunJobRequest{}
@@ -185,7 +185,7 @@ func (c *Client) RunJob(id string, opts ...RunJobOption) (*Execution, error) {
 // ListJobs lists the jobs for a project
 // http://rundeck.org/docs/api/index.html#listing-jobs
 func (c *Client) ListJobs(projectID string) (*JobList, error) {
-	if _, err := c.hasRequiredAPIVersion(17, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.JobsResponse{}); err != nil {
 		return nil, err
 	}
 	data := &JobList{}
@@ -203,7 +203,7 @@ func (c *Client) ListJobs(projectID string) (*JobList, error) {
 // BulkJobDelete deletes jobs in bulk
 // http://rundeck.org/docs/api/index.html#bulk-job-delete
 func (c *Client) BulkJobDelete(ids ...string) error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.BulkDeleteJobResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -212,7 +212,7 @@ func (c *Client) BulkJobDelete(ids ...string) error {
 // GetExecutionsForJob gets executions for a job
 // http://rundeck.org/docs/api/index.html#getting-executions-for-a-job
 func (c *Client) GetExecutionsForJob(jobid string) error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.JobExecutionsResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -221,7 +221,7 @@ func (c *Client) GetExecutionsForJob(jobid string) error {
 // DeleteAllExecutionsForJob deletes all executions for a job
 // http://rundeck.org/docs/api/index.html#delete-all-executions-for-a-job
 func (c *Client) DeleteAllExecutionsForJob(jobid string) error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.BulkDeleteExecutionsResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -230,7 +230,7 @@ func (c *Client) DeleteAllExecutionsForJob(jobid string) error {
 // UploadFileForJobOption uploads a file for a job 'file' option type
 // http://rundeck.org/docs/api/index.html#upload-a-file-for-a-job-option
 func (c *Client) UploadFileForJobOption(ids ...string) error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.JobOptionFileUploadResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -239,7 +239,7 @@ func (c *Client) UploadFileForJobOption(ids ...string) error {
 // ListFilesUploadedForJob lists files that have been uploaded for a job
 // http://rundeck.org/docs/api/index.html#list-files-uploaded-for-a-job
 func (c *Client) ListFilesUploadedForJob(ids ...string) error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.UploadedJobInputFilesResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -248,7 +248,7 @@ func (c *Client) ListFilesUploadedForJob(ids ...string) error {
 // GetUploadedFileInfo gets info about an uploaded file
 // http://rundeck.org/docs/api/index.html#get-info-about-an-uploaded-file
 func (c *Client) GetUploadedFileInfo(ids ...string) error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.UploadedJobInputFileResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")

--- a/pkg/rundeck/job.go
+++ b/pkg/rundeck/job.go
@@ -102,7 +102,7 @@ func (c *Client) GetJobMetaData(id string) (*JobMetaData, error) {
 // GetJobDefinition gets a job definition
 // http://rundeck.org/docs/api/index.html#getting-a-job-definition
 func (c *Client) GetJobDefinition(id string, format string) ([]byte, error) {
-	if _, err := c.hasRequiredAPIVersion(1, maxRundeckVersionInt); err != nil {
+	if _, err := c.hasRequiredAPIVersion(14, maxRundeckVersionInt); err != nil {
 		return nil, err
 	}
 	options := []httpclient.RequestOption{

--- a/pkg/rundeck/job_import.go
+++ b/pkg/rundeck/job_import.go
@@ -48,7 +48,7 @@ func ImportUUID(f string) JobImportOption {
 // ImportJob imports a job
 // http://rundeck.org/docs/api/index.html#importing-jobs
 func (c *Client) ImportJob(project string, data io.Reader, opt ...JobImportOption) (*JobImportResult, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ImportedJobResponse{}); err != nil {
 		return nil, err
 	}
 	jobRes := &JobImportResult{}

--- a/pkg/rundeck/keys.go
+++ b/pkg/rundeck/keys.go
@@ -1,11 +1,15 @@
 package rundeck
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/lusis/go-rundeck/pkg/rundeck/responses"
+)
 
 // UploadKey stores keys on the rundeck server
 // http://rundeck.org/docs/api/index.html#upload-keys
 func (c *Client) UploadKey() error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.GenericVersionedResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -14,7 +18,7 @@ func (c *Client) UploadKey() error {
 // ListKeys lists key resources
 // http://rundeck.org/docs/api/index.html#list-keys
 func (c *Client) ListKeys() error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ListKeysResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -23,7 +27,7 @@ func (c *Client) ListKeys() error {
 // GetKeyMetaData returns the metadata about a stored key
 // http://rundeck.org/docs/api/index.html#get-key-metadata
 func (c *Client) GetKeyMetaData() error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.KeyMetaResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -32,7 +36,7 @@ func (c *Client) GetKeyMetaData() error {
 // GetKeyContents provides the public key content
 // http://rundeck.org/docs/api/index.html#get-key-contents
 func (c *Client) GetKeyContents() error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.GenericVersionedResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -41,7 +45,7 @@ func (c *Client) GetKeyContents() error {
 // DeleteKey deletes a key
 // http://rundeck.org/docs/api/index.html#delete-keys
 func (c *Client) DeleteKey() error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.GenericVersionedResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")

--- a/pkg/rundeck/logstorage.go
+++ b/pkg/rundeck/logstorage.go
@@ -16,7 +16,7 @@ type IncompleteLogStorage responses.IncompleteLogStorageResponse
 // GetLogStorageInfo gets the logstorage
 // http://rundeck.org/docs/api/index.html#log-storage-info
 func (c *Client) GetLogStorageInfo() (*LogStorage, error) {
-	if _, err := c.hasRequiredAPIVersion(17, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.LogStorageResponse{}); err != nil {
 		return nil, err
 	}
 	ls := &LogStorage{}
@@ -33,7 +33,7 @@ func (c *Client) GetLogStorageInfo() (*LogStorage, error) {
 // GetIncompleteLogStorage gets executions with incomplete logstorage
 // http://rundeck.org/docs/api/index.html#list-executions-with-incomplete-log-storage
 func (c *Client) GetIncompleteLogStorage() (*IncompleteLogStorage, error) {
-	if _, err := c.hasRequiredAPIVersion(17, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.IncompleteLogStorageResponse{}); err != nil {
 		return nil, err
 	}
 	ls := &IncompleteLogStorage{}
@@ -50,7 +50,7 @@ func (c *Client) GetIncompleteLogStorage() (*IncompleteLogStorage, error) {
 // ResumeIncompleteLogStorage resumes processing incomplete log storage uploads
 // http://rundeck.org/docs/api/index.html#resume-incomplete-log-storage
 func (c *Client) ResumeIncompleteLogStorage() (bool, error) {
-	if _, err := c.hasRequiredAPIVersion(17, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.IncompleteLogStorageResponse{}); err != nil {
 		return false, err
 	}
 	res := make(map[string]bool)

--- a/pkg/rundeck/projects.go
+++ b/pkg/rundeck/projects.go
@@ -85,7 +85,7 @@ func ProjectExportAcls(b bool) ProjectExportOption {
 // GetProjectInfo gets a project by name
 // http://rundeck.org/docs/api/index.html#getting-project-info
 func (c *Client) GetProjectInfo(name string) (*Project, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectInfoResponse{}); err != nil {
 		return nil, err
 	}
 	p := &responses.ProjectInfoResponse{}
@@ -109,7 +109,7 @@ func (c *Client) GetProjectInfo(name string) (*Project, error) {
 // ListProjects lists all projects
 // http://rundeck.org/docs/api/index.html#listing-projects
 func (c *Client) ListProjects() (*Projects, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ListProjectsResponse{}); err != nil {
 		return nil, err
 	}
 	data := &responses.ListProjectsResponse{}
@@ -134,7 +134,7 @@ func (c *Client) ListProjects() (*Projects, error) {
 // CreateProject makes a project
 // http://rundeck.org/docs/api/index.html#project-creation
 func (c *Client) CreateProject(name string, properties map[string]string) (*Project, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectInfoResponse{}); err != nil {
 		return nil, err
 	}
 	req := &requests.ProjectCreationRequest{
@@ -162,7 +162,7 @@ func (c *Client) CreateProject(name string, properties map[string]string) (*Proj
 // DeleteProject deletes a project
 // http://rundeck.org/docs/api/index.html#project-deletion
 func (c *Client) DeleteProject(p string) error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectInfoResponse{}); err != nil {
 		return err
 	}
 	url := fmt.Sprintf("project/%s", p)
@@ -172,7 +172,7 @@ func (c *Client) DeleteProject(p string) error {
 // GetProjectConfiguration gets a project's configuration
 // http://rundeck.org/docs/api/index.html#get-project-configuration
 func (c *Client) GetProjectConfiguration(p string) (*responses.ProjectConfigResponse, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectConfigResponse{}); err != nil {
 		return nil, err
 	}
 	data := &responses.ProjectConfigResponse{}
@@ -189,7 +189,7 @@ func (c *Client) GetProjectConfiguration(p string) (*responses.ProjectConfigResp
 // PutProjectConfiguration replaces all configuration data with the submitted values
 // http://rundeck.org/docs/api/index.html#put-project-configuration
 func (c *Client) PutProjectConfiguration() error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectConfigResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -198,7 +198,7 @@ func (c *Client) PutProjectConfiguration() error {
 // GetProjectConfigurationKey gets a specific configuration key
 // http://rundeck.org/docs/api/index.html#get-project-configuration-key
 func (c *Client) GetProjectConfigurationKey() error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectConfigItemResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -207,7 +207,7 @@ func (c *Client) GetProjectConfigurationKey() error {
 // PutProjectConfigurationKey sets a value for a configuration key
 // http://rundeck.org/docs/api/index.html#put-project-configuration-key
 func (c *Client) PutProjectConfigurationKey() error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectConfigItemResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -216,7 +216,7 @@ func (c *Client) PutProjectConfigurationKey() error {
 // DeleteProjectConfigurationKey deletes a configuration key
 // http://rundeck.org/docs/api/index.html#delete-project-configuration-key
 func (c *Client) DeleteProjectConfigurationKey() error {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectConfigItemResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -225,7 +225,7 @@ func (c *Client) DeleteProjectConfigurationKey() error {
 // GetProjectArchiveExport export exports a zip file of the project
 // http://rundeck.org/docs/api/index.html#project-archive-export
 func (c *Client) GetProjectArchiveExport(p string, w io.Writer, opts ...ProjectExportOption) error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectInfoResponse{}); err != nil {
 		return err
 	}
 	params := &map[string]string{}
@@ -250,7 +250,7 @@ func (c *Client) GetProjectArchiveExport(p string, w io.Writer, opts ...ProjectE
 // GetProjectArchiveExportAsync export a zip archive of a project async
 // http://rundeck.org/docs/api/index.html#project-archive-export-async
 func (c *Client) GetProjectArchiveExportAsync() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectArchiveExportAsyncResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -259,7 +259,7 @@ func (c *Client) GetProjectArchiveExportAsync() error {
 // GetProjectArchiveExportAsyncStatus gets the status of an async export request
 // http://rundeck.org/docs/api/index.html#project-archive-export-async-status
 func (c *Client) GetProjectArchiveExportAsyncStatus() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectArchiveExportAsyncResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -268,7 +268,7 @@ func (c *Client) GetProjectArchiveExportAsyncStatus() error {
 // GetProjectArchiveExportAsyncDownload downloads an async project export archive file
 // http://rundeck.org/docs/api/index.html#project-archive-export-async-download
 func (c *Client) GetProjectArchiveExportAsyncDownload() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectArchiveExportAsyncResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -277,7 +277,7 @@ func (c *Client) GetProjectArchiveExportAsyncDownload() error {
 // ProjectArchiveImport imports a zip archive to a project
 // http://rundeck.org/docs/api/index.html#project-archive-import
 func (c *Client) ProjectArchiveImport() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ProjectImportArchiveResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")

--- a/pkg/rundeck/resources.go
+++ b/pkg/rundeck/resources.go
@@ -17,7 +17,7 @@ type Resource responses.ResourceResponse
 // ListResourcesForProject returns resources for a project (usually nodes)
 // http://rundeck.org/docs/api/index.html#list-resources-for-a-project
 func (c *Client) ListResourcesForProject(p string) (*Resources, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ResourceCollectionResponse{}); err != nil {
 		return nil, err
 	}
 	ls := &Resources{}
@@ -34,7 +34,7 @@ func (c *Client) ListResourcesForProject(p string) (*Resources, error) {
 // GetResourceInfo get a specific resource within a project (usually a node)
 // http://rundeck.org/docs/api/index.html#getting-resource-info
 func (c *Client) GetResourceInfo(p, n string) (*responses.ResourceDetailResponse, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ResourceDetailResponse{}); err != nil {
 		return nil, err
 	}
 	r := Resource{}
@@ -52,7 +52,7 @@ func (c *Client) GetResourceInfo(p, n string) (*responses.ResourceDetailResponse
 // UpdateResource updates a project resource
 // http://rundeck.org/docs/api/index.html#list-resources-for-a-project
 func (c *Client) UpdateResource() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ResourceResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -61,7 +61,7 @@ func (c *Client) UpdateResource() error {
 // GetProjectReadme gets a project's readme.md
 // http://rundeck.org/docs/api/index.html#get-readme-file
 func (c *Client) GetProjectReadme() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ResourceResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -70,7 +70,7 @@ func (c *Client) GetProjectReadme() error {
 // PutProjectReadme creates or modifies a project's readme.md
 // http://rundeck.org/docs/api/index.html#put-readme-file
 func (c *Client) PutProjectReadme() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ResourceResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -78,7 +78,7 @@ func (c *Client) PutProjectReadme() error {
 
 // DeleteProjectReadme deletes a project's readme.md
 func (c *Client) DeleteProjectReadme() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ResourceResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -87,7 +87,7 @@ func (c *Client) DeleteProjectReadme() error {
 // GetProjectMotd gets a project's Motd.md
 // http://rundeck.org/docs/api/index.html#get-readme-file
 func (c *Client) GetProjectMotd() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ResourceResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -96,7 +96,7 @@ func (c *Client) GetProjectMotd() error {
 // PutProjectMotd creates or modifies a project's motd.md
 // http://rundeck.org/docs/api/index.html#put-readme-file
 func (c *Client) PutProjectMotd() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ResourceResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -104,7 +104,7 @@ func (c *Client) PutProjectMotd() error {
 
 // DeleteProjectMotd deletes a project's motd.md
 func (c *Client) DeleteProjectMotd() error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ResourceResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")

--- a/pkg/rundeck/responses/acl.go
+++ b/pkg/rundeck/responses/acl.go
@@ -22,6 +22,10 @@ type ACLResponse struct {
 	Resources []ACLResourceResponse `json:"resources,omitempty"`
 }
 
+func (a ACLResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ACLResponse) maxVersion() int  { return CurrentVersion }
+func (a ACLResponse) deprecated() bool { return false }
+
 // FromReader returns an ACLResponse from an io.Reader
 func (a *ACLResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
@@ -55,17 +59,29 @@ type ACLResourceResponse struct {
 	Name string `json:"name,omitempty"`
 }
 
+func (a ACLResourceResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ACLResourceResponse) maxVersion() int  { return CurrentVersion }
+func (a ACLResourceResponse) deprecated() bool { return false }
+
 // FailedACLValidationResponse represents a failed ACL validation response
 type FailedACLValidationResponse struct {
 	Valid    bool                      `json:"valid"`
 	Policies []FailedACLPolicyResponse `json:"policies"`
 }
 
+func (a FailedACLValidationResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a FailedACLValidationResponse) maxVersion() int  { return CurrentVersion }
+func (a FailedACLValidationResponse) deprecated() bool { return false }
+
 // FailedACLPolicyResponse represents a failed ACL policy
 type FailedACLPolicyResponse struct {
 	Policy string   `json:"policy"`
 	Errors []string `json:"errors"`
 }
+
+func (a FailedACLPolicyResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a FailedACLPolicyResponse) maxVersion() int  { return CurrentVersion }
+func (a FailedACLPolicyResponse) deprecated() bool { return false }
 
 // FromReader returns a FailedACLValidationResponse from an io.Reader
 func (a *FailedACLValidationResponse) FromReader(i io.Reader) error {

--- a/pkg/rundeck/responses/acl_test.go
+++ b/pkg/rundeck/responses/acl_test.go
@@ -20,6 +20,7 @@ func TestACLResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, "", obj.Path)
 	assert.Equal(t, "directory", obj.Type)
 	assert.Equal(t, "[API Href]", obj.Href)
@@ -44,6 +45,7 @@ func TestFailedACLValidationResponse(t *testing.T) {
 		t.Error(bErr.Error())
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.False(t, obj.Valid)
 	assert.Len(t, obj.Policies, 2)
 	first := obj.Policies[0]

--- a/pkg/rundeck/responses/errors.go
+++ b/pkg/rundeck/responses/errors.go
@@ -10,3 +10,7 @@ type ErrorResponse struct {
 	ErrorCode  string `json:"errorCode"`
 	Message    string `json:"message"`
 }
+
+func (a ErrorResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ErrorResponse) maxVersion() int  { return CurrentVersion }
+func (a ErrorResponse) deprecated() bool { return false }

--- a/pkg/rundeck/responses/executions.go
+++ b/pkg/rundeck/responses/executions.go
@@ -11,6 +11,10 @@ import (
 // JobExecutionsResponse is the response for listing the executions for a job
 type JobExecutionsResponse ListRunningExecutionsResponse
 
+func (a JobExecutionsResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a JobExecutionsResponse) maxVersion() int  { return CurrentVersion }
+func (a JobExecutionsResponse) deprecated() bool { return false }
+
 // ListRunningExecutionsResponseTestFile is the test data for JobExecutionResponse
 const ListRunningExecutionsResponseTestFile = "executions.json"
 
@@ -392,3 +396,20 @@ type AdHocExecutionItemResponse struct {
 func (a AdHocExecutionItemResponse) minVersion() int  { return AbsoluteMinimumVersion }
 func (a AdHocExecutionItemResponse) maxVersion() int  { return CurrentVersion }
 func (a AdHocExecutionItemResponse) deprecated() bool { return false }
+
+// AbortExecutionResponse is the response for aborting an execution
+type AbortExecutionResponse struct {
+	Abort struct {
+		Status string `json:"status"`
+		Reason string `json:"reason"`
+	} `json:"abort"`
+	Execution struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+		HRef   string `json:"href"`
+	} `json:"execution"`
+}
+
+func (a AbortExecutionResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a AbortExecutionResponse) maxVersion() int  { return CurrentVersion }
+func (a AbortExecutionResponse) deprecated() bool { return false }

--- a/pkg/rundeck/responses/executions.go
+++ b/pkg/rundeck/responses/executions.go
@@ -14,17 +14,6 @@ type JobExecutionsResponse ListRunningExecutionsResponse
 // ListRunningExecutionsResponseTestFile is the test data for JobExecutionResponse
 const ListRunningExecutionsResponseTestFile = "executions.json"
 
-// SuccessToggleResponseTestFile is the test data for a successful toggle
-const SuccessToggleResponseTestFile = "success.json"
-
-// FailToggleResponseTestFile is the test data for a successful toggle
-const FailToggleResponseTestFile = "failed.json"
-
-// ToggleResponse is the response for a toggled job, exeuction or schedule
-type ToggleResponse struct {
-	Success bool `json:"success"`
-}
-
 // ListRunningExecutionsResponse is the response for listing the running executions for a project
 type ListRunningExecutionsResponse struct {
 	Paging     PagingResponse      `json:"paging"`

--- a/pkg/rundeck/responses/executions.go
+++ b/pkg/rundeck/responses/executions.go
@@ -20,6 +20,10 @@ type ListRunningExecutionsResponse struct {
 	Executions []ExecutionResponse `json:"executions"`
 }
 
+func (a ListRunningExecutionsResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ListRunningExecutionsResponse) maxVersion() int  { return CurrentVersion }
+func (a ListRunningExecutionsResponse) deprecated() bool { return false }
+
 // FromReader returns an ListRunningExecutionsResponse from an io.Reader
 func (a *ListRunningExecutionsResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
@@ -73,6 +77,10 @@ type ExecutionResponse struct {
 	FailedNodes     []string                  `json:"failedNodes"`
 }
 
+func (a ExecutionResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ExecutionResponse) maxVersion() int  { return CurrentVersion }
+func (a ExecutionResponse) deprecated() bool { return false }
+
 // FromReader returns an ExecutionResponse from an io.Reader
 func (a *ExecutionResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
@@ -111,6 +119,10 @@ type ExecutionJobEntryResponse struct {
 	Options         map[string]string `json:"options"`
 }
 
+func (a ExecutionJobEntryResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ExecutionJobEntryResponse) maxVersion() int  { return CurrentVersion }
+func (a ExecutionJobEntryResponse) deprecated() bool { return false }
+
 // ExecutionInputFileResponse is an individual execution input file entry response
 type ExecutionInputFileResponse struct {
 	ID             string    `json:"id"`
@@ -126,6 +138,10 @@ type ExecutionInputFileResponse struct {
 	ExecID         int       `json:"execId"`
 }
 
+func (a ExecutionInputFileResponse) minVersion() int  { return 19 }
+func (a ExecutionInputFileResponse) maxVersion() int  { return CurrentVersion }
+func (a ExecutionInputFileResponse) deprecated() bool { return false }
+
 // ExecutionInputFilesResponseTestFile is test data for an ExecutionInputFileResponse
 const ExecutionInputFilesResponseTestFile = "execution_input_files.json"
 
@@ -133,6 +149,10 @@ const ExecutionInputFilesResponseTestFile = "execution_input_files.json"
 type ExecutionInputFilesResponse struct {
 	Files []ExecutionInputFileResponse `json:"files"`
 }
+
+func (a ExecutionInputFilesResponse) minVersion() int  { return 19 }
+func (a ExecutionInputFilesResponse) maxVersion() int  { return CurrentVersion }
+func (a ExecutionInputFilesResponse) deprecated() bool { return false }
 
 // FromReader returns an ExecutionInputFilesResponse from an io.Reader
 func (a *ExecutionInputFilesResponse) FromReader(i io.Reader) error {
@@ -170,6 +190,10 @@ type BulkDeleteExecutionsResponse struct {
 	RequestCount  int                                  `json:"requestCount"`
 	Failures      []BulkDeleteExecutionFailureResponse `json:"failures"`
 }
+
+func (a BulkDeleteExecutionsResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a BulkDeleteExecutionsResponse) maxVersion() int  { return CurrentVersion }
+func (a BulkDeleteExecutionsResponse) deprecated() bool { return false }
 
 // FromReader returns an BulkDeleteExecutionsResponse from an io.Reader
 func (a *BulkDeleteExecutionsResponse) FromReader(i io.Reader) error {
@@ -221,6 +245,10 @@ type ExecutionStateResponse struct {
 	Steps          []json.RawMessage                            `json:"steps"`
 }
 
+func (a ExecutionStateResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ExecutionStateResponse) maxVersion() int  { return CurrentVersion }
+func (a ExecutionStateResponse) deprecated() bool { return false }
+
 // FromReader returns an ExecutionStateResponse from an io.Reader
 func (a *ExecutionStateResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
@@ -257,6 +285,10 @@ type ExecutionStepResponse struct {
 	StartTime      *JSONTime                     `json:"startTime"`
 }
 
+func (a ExecutionStepResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ExecutionStepResponse) maxVersion() int  { return CurrentVersion }
+func (a ExecutionStepResponse) deprecated() bool { return false }
+
 // WorkflowResponse represents a workflow response
 type WorkflowResponse struct {
 	Completed      bool              `json:"completed"`
@@ -270,6 +302,10 @@ type WorkflowResponse struct {
 	Steps          []json.RawMessage `json:"steps"`
 }
 
+func (a WorkflowResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a WorkflowResponse) maxVersion() int  { return CurrentVersion }
+func (a WorkflowResponse) deprecated() bool { return false }
+
 // WorkflowStepResponse represents a workflow step response
 type WorkflowStepResponse struct {
 	Workflow       *WorkflowResponse `json:"workflow"`
@@ -282,6 +318,10 @@ type WorkflowStepResponse struct {
 	ID             string            `json:"id"`
 }
 
+func (a WorkflowStepResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a WorkflowStepResponse) maxVersion() int  { return CurrentVersion }
+func (a WorkflowStepResponse) deprecated() bool { return false }
+
 // NodeStateResponse represents a nodeState response
 type NodeStateResponse struct {
 	ExecutionState string    `json:"executionState"`
@@ -290,11 +330,19 @@ type NodeStateResponse struct {
 	StartTime      *JSONTime `json:"startTime"`
 }
 
+func (a NodeStateResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a NodeStateResponse) maxVersion() int  { return CurrentVersion }
+func (a NodeStateResponse) deprecated() bool { return false }
+
 // ExecutionStateNodeEntryResponse represents an individual node entry response
 type ExecutionStateNodeEntryResponse struct {
 	ExecutionState string `json:"executionState"`
 	StepCtx        string `json:"stepctx"`
 }
+
+func (a ExecutionStateNodeEntryResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ExecutionStateNodeEntryResponse) maxVersion() int  { return CurrentVersion }
+func (a ExecutionStateNodeEntryResponse) deprecated() bool { return false }
 
 // AdHocExecutionResponseTestFile is the test data for an AdHocExecutionResponse
 const AdHocExecutionResponseTestFile = "execution_adhoc.json"
@@ -304,6 +352,10 @@ type AdHocExecutionResponse struct {
 	Message   string                     `json:"message"`
 	Execution AdHocExecutionItemResponse `json:"execution"`
 }
+
+func (a AdHocExecutionResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a AdHocExecutionResponse) maxVersion() int  { return CurrentVersion }
+func (a AdHocExecutionResponse) deprecated() bool { return false }
 
 // FromReader returns an AdHocExecutionResponse from an io.Reader
 func (a *AdHocExecutionResponse) FromReader(i io.Reader) error {
@@ -336,3 +388,7 @@ type AdHocExecutionItemResponse struct {
 	HRef      string `json:"href"`
 	Permalink string `json:"permalink"`
 }
+
+func (a AdHocExecutionItemResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a AdHocExecutionItemResponse) maxVersion() int  { return CurrentVersion }
+func (a AdHocExecutionItemResponse) deprecated() bool { return false }

--- a/pkg/rundeck/responses/executions_test.go
+++ b/pkg/rundeck/responses/executions_test.go
@@ -20,6 +20,7 @@ func TestExecutionResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, 1, obj.ID)
 	assert.Equal(t, "[url]", obj.HRef)
 	assert.Equal(t, "[url]", obj.Permalink)
@@ -59,6 +60,7 @@ func TestListRunningExecutionsResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Len(t, obj.Executions, 1)
 	assert.Len(t, obj.Executions[0].FailedNodes, 2)
 	assert.Len(t, obj.Executions[0].SuccessfulNodes, 1)
@@ -82,6 +84,7 @@ func TestExecutionInputFilesResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Len(t, obj.Files, 1)
 	assert.Equal(t, 2014, obj.Files[0].DateCreated.Year())
 	assert.Equal(t, 2017, obj.Files[0].ExpirationDate.Year())
@@ -99,6 +102,7 @@ func TestBulkDeleteExecutionsResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Len(t, obj.Failures, 3)
 	for _, f := range obj.Failures {
 		assert.NotEmpty(t, f.ID)
@@ -122,6 +126,7 @@ func TestExecutionStateResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.True(t, obj.Completed)
 	assert.Equal(t, "SUCCEEDED", obj.ExecutionState)
 	assert.NotNil(t, obj.EndTime)
@@ -164,6 +169,7 @@ func TestAdHocExecutionResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, "Immediate execution scheduled (X)", obj.Message)
 	assert.Equal(t, 1, obj.Execution.ID)
 	assert.Equal(t, "[API Href]", obj.Execution.HRef)

--- a/pkg/rundeck/responses/history.go
+++ b/pkg/rundeck/responses/history.go
@@ -12,9 +12,25 @@ import (
 const HistoryResponseTestFile = "history.json"
 
 // HistoryResponse represents a project history response
+// http://rundeck.org/docs/api/index.html#listing-history
 type HistoryResponse struct {
 	Paging *PagingResponse         `json:"paging"`
 	Events []*HistoryEventResponse `json:"events"`
+}
+
+// MinVersion is the minimum version of the API required for this response
+func (a HistoryResponse) MinVersion() int {
+	return 14
+}
+
+// MaxVersion is the maximum version of the API that this response supports
+func (a HistoryResponse) MaxVersion() int {
+	return CurrentVersion
+}
+
+// Deprecated is if a given response is deprecated
+func (a HistoryResponse) Deprecated() bool {
+	return false
 }
 
 // FromReader returns a HistoryResponse from an io.Reader
@@ -63,4 +79,19 @@ type HistoryEventResponse struct {
 		HRef      string `json:"href"`
 		Permalink string `json:"permalink"`
 	} `json:"execution"`
+}
+
+// MinVersion is the minimum version of the API required for this response
+func (a HistoryEventResponse) MinVersion() int {
+	return 14
+}
+
+// MaxVersion is the maximum version of the API that this response supports
+func (a HistoryEventResponse) MaxVersion() int {
+	return CurrentVersion
+}
+
+// Deprecated is if a given response is deprecated
+func (a HistoryEventResponse) Deprecated() bool {
+	return false
 }

--- a/pkg/rundeck/responses/history.go
+++ b/pkg/rundeck/responses/history.go
@@ -18,20 +18,9 @@ type HistoryResponse struct {
 	Events []*HistoryEventResponse `json:"events"`
 }
 
-// MinVersion is the minimum version of the API required for this response
-func (a HistoryResponse) MinVersion() int {
-	return 14
-}
-
-// MaxVersion is the maximum version of the API that this response supports
-func (a HistoryResponse) MaxVersion() int {
-	return CurrentVersion
-}
-
-// Deprecated is if a given response is deprecated
-func (a HistoryResponse) Deprecated() bool {
-	return false
-}
+func (a HistoryResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a HistoryResponse) maxVersion() int  { return CurrentVersion }
+func (a HistoryResponse) deprecated() bool { return false }
 
 // FromReader returns a HistoryResponse from an io.Reader
 func (a *HistoryResponse) FromReader(i io.Reader) error {
@@ -81,17 +70,6 @@ type HistoryEventResponse struct {
 	} `json:"execution"`
 }
 
-// MinVersion is the minimum version of the API required for this response
-func (a HistoryEventResponse) MinVersion() int {
-	return 14
-}
-
-// MaxVersion is the maximum version of the API that this response supports
-func (a HistoryEventResponse) MaxVersion() int {
-	return CurrentVersion
-}
-
-// Deprecated is if a given response is deprecated
-func (a HistoryEventResponse) Deprecated() bool {
-	return false
-}
+func (a HistoryEventResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a HistoryEventResponse) maxVersion() int  { return CurrentVersion }
+func (a HistoryEventResponse) deprecated() bool { return false }

--- a/pkg/rundeck/responses/history_test.go
+++ b/pkg/rundeck/responses/history_test.go
@@ -19,6 +19,7 @@ func TestHistoryResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Len(t, obj.Events, 6)
 	for _, e := range obj.Events {
 		assert.NotNil(t, e)

--- a/pkg/rundeck/responses/job.go
+++ b/pkg/rundeck/responses/job.go
@@ -12,6 +12,10 @@ import (
 // JobsResponse is a collection of JobResponse
 type JobsResponse []*JobResponse
 
+func (a JobsResponse) minVersion() int  { return 17 }
+func (a JobsResponse) maxVersion() int  { return CurrentVersion }
+func (a JobsResponse) deprecated() bool { return false }
+
 // JobsResponseTestFile is the test data for JobsResponse
 const JobsResponseTestFile = "jobs.json"
 
@@ -57,6 +61,10 @@ type JobResponse struct {
 	ServerOwned    bool   `json:"serverOwned"`
 }
 
+func (a JobResponse) minVersion() int  { return 17 }
+func (a JobResponse) maxVersion() int  { return CurrentVersion }
+func (a JobResponse) deprecated() bool { return false }
+
 // JobMetaDataResponseTestFile is the test data for a JobMetaDataResponse
 const JobMetaDataResponseTestFile = "job_metadata.json"
 
@@ -74,6 +82,10 @@ type JobMetaDataResponse struct {
 	Enabled         bool   `json:"enabled"`
 	AverageDuration int64  `json:"averageDuration"`
 }
+
+func (a JobMetaDataResponse) minVersion() int  { return 18 }
+func (a JobMetaDataResponse) maxVersion() int  { return CurrentVersion }
+func (a JobMetaDataResponse) deprecated() bool { return false }
 
 // FromReader returns a JobMetaDataResponse from an io.Reader
 func (a *JobMetaDataResponse) FromReader(i io.Reader) error {
@@ -112,6 +124,10 @@ type ImportedJobEntryResponse struct {
 	Messages  string `json:"error,omitempty"`
 }
 
+func (a ImportedJobEntryResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ImportedJobEntryResponse) maxVersion() int  { return CurrentVersion }
+func (a ImportedJobEntryResponse) deprecated() bool { return false }
+
 // ImportedJobResponseTestFile is the test data for an ImportedJobResponse
 const ImportedJobResponseTestFile = "imported_job.json"
 
@@ -121,6 +137,10 @@ type ImportedJobResponse struct {
 	Failed    []ImportedJobEntryResponse `json:"failed"`
 	Skipped   []ImportedJobEntryResponse `json:"skipped"`
 }
+
+func (a ImportedJobResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ImportedJobResponse) maxVersion() int  { return CurrentVersion }
+func (a ImportedJobResponse) deprecated() bool { return false }
 
 // FromReader returns a ImportedJobResponse from an io.Reader
 func (a *ImportedJobResponse) FromReader(i io.Reader) error {
@@ -147,23 +167,31 @@ func (a *ImportedJobResponse) FromBytes(f []byte) error {
 	return a.FromReader(file)
 }
 
-// BulkJobEntryReponse represents a bulk job entry response
-type BulkJobEntryReponse struct {
+// BulkJobEntryResponse represents a bulk job entry response
+type BulkJobEntryResponse struct {
 	ID        string `json:"id"`
 	Message   string `json:"message"`
 	ErrorCode string `json:"errorCode,omitempty"`
 }
+
+func (a BulkJobEntryResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a BulkJobEntryResponse) maxVersion() int  { return CurrentVersion }
+func (a BulkJobEntryResponse) deprecated() bool { return false }
 
 // BulkDeleteJobResponseTestFile is the test data for BulkDeleteJobResponse
 const BulkDeleteJobResponseTestFile = "bulk_job_delete.json"
 
 // BulkDeleteJobResponse represents a bulk job delete response
 type BulkDeleteJobResponse struct {
-	RequestCount  int                   `json:"requestCount"`
-	AllSuccessful bool                  `json:"allSuccessful"`
-	Succeeded     []BulkJobEntryReponse `json:"succeeeded"`
-	Failed        []BulkJobEntryReponse `json:"failed"`
+	RequestCount  int                    `json:"requestCount"`
+	AllSuccessful bool                   `json:"allSuccessful"`
+	Succeeded     []BulkJobEntryResponse `json:"succeeeded"`
+	Failed        []BulkJobEntryResponse `json:"failed"`
 }
+
+func (a BulkDeleteJobResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a BulkDeleteJobResponse) maxVersion() int  { return CurrentVersion }
+func (a BulkDeleteJobResponse) deprecated() bool { return false }
 
 // FromReader returns a BulkDeleteJobResponse from an io.Reader
 func (a *BulkDeleteJobResponse) FromReader(i io.Reader) error {
@@ -198,6 +226,10 @@ type JobOptionFileUploadResponse struct {
 	Total   int               `json:"total"`
 	Options map[string]string `json:"options"`
 }
+
+func (a JobOptionFileUploadResponse) minVersion() int  { return 19 }
+func (a JobOptionFileUploadResponse) maxVersion() int  { return CurrentVersion }
+func (a JobOptionFileUploadResponse) deprecated() bool { return false }
 
 // FromReader returns a JobOptionFileUploadResponse from an io.Reader
 func (a *JobOptionFileUploadResponse) FromReader(i io.Reader) error {
@@ -239,6 +271,10 @@ type UploadedJobInputFileResponse struct {
 	ExecID         int       `json:"execId"`
 }
 
+func (a UploadedJobInputFileResponse) minVersion() int  { return 19 }
+func (a UploadedJobInputFileResponse) maxVersion() int  { return CurrentVersion }
+func (a UploadedJobInputFileResponse) deprecated() bool { return false }
+
 // UploadedJobInputFilesResponseTestFile is the test data for a UploadedJobInputFileResponse
 const UploadedJobInputFilesResponseTestFile = "uploaded_job_input_files.json"
 
@@ -247,6 +283,10 @@ type UploadedJobInputFilesResponse struct {
 	Paging PagingResponse                 `json:"paging"`
 	Files  []UploadedJobInputFileResponse `json:"files"`
 }
+
+func (a UploadedJobInputFilesResponse) minVersion() int  { return 19 }
+func (a UploadedJobInputFilesResponse) maxVersion() int  { return CurrentVersion }
+func (a UploadedJobInputFilesResponse) deprecated() bool { return false }
 
 // FromReader returns a UploadedJobInputFilesResponse from an io.Reader
 func (a *UploadedJobInputFilesResponse) FromReader(i io.Reader) error {

--- a/pkg/rundeck/responses/job_definition.go
+++ b/pkg/rundeck/responses/job_definition.go
@@ -3,6 +3,10 @@ package responses
 // JobYAMLResponse represents a rundeck job-yaml response
 type JobYAMLResponse []*JobYAMLDetailResponse
 
+func (a JobYAMLResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a JobYAMLResponse) maxVersion() int  { return CurrentVersion }
+func (a JobYAMLResponse) deprecated() bool { return false }
+
 // JobYAMLDetailResponse represents the details of a yaml job definition response
 type JobYAMLDetailResponse struct {
 	Description        string                   `yaml:"description"`
@@ -18,6 +22,10 @@ type JobYAMLDetailResponse struct {
 	Sequence           *JobCommandsYAMLResponse `yaml:"sequence"`
 }
 
+func (a JobYAMLDetailResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a JobYAMLDetailResponse) maxVersion() int  { return CurrentVersion }
+func (a JobYAMLDetailResponse) deprecated() bool { return false }
+
 // JobOptionYAMLResponse represents a jobs options in a yaml job definition response
 type JobOptionYAMLResponse struct {
 	Description string `yaml:"description,omitempty"`
@@ -27,7 +35,15 @@ type JobOptionYAMLResponse struct {
 	Value       string `yaml:"value,omitempty"`
 }
 
+func (a JobOptionYAMLResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a JobOptionYAMLResponse) maxVersion() int  { return CurrentVersion }
+func (a JobOptionYAMLResponse) deprecated() bool { return false }
+
 // JobCommandsYAMLResponse represents a jobs commands in a yaml job definition response
 type JobCommandsYAMLResponse struct {
 	Commands map[string]interface{} `yaml:"commands,inline"`
 }
+
+func (a JobCommandsYAMLResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a JobCommandsYAMLResponse) maxVersion() int  { return CurrentVersion }
+func (a JobCommandsYAMLResponse) deprecated() bool { return false }

--- a/pkg/rundeck/responses/job_test.go
+++ b/pkg/rundeck/responses/job_test.go
@@ -19,6 +19,7 @@ func TestJobsResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Len(t, obj, 1)
 	assert.Equal(t, "[UUID]", obj[0].ID)
 	assert.Equal(t, "[name]", obj[0].Name)
@@ -47,6 +48,7 @@ func TestJobMetaDataResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, "[UUID]", obj.ID)
 	assert.Equal(t, "[name]", obj.Name)
 	assert.Equal(t, "[group]", obj.Group)
@@ -72,6 +74,7 @@ func TestImportedJobResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 }
 
 func TestBulkDeleteJobResponse(t *testing.T) {
@@ -86,6 +89,7 @@ func TestBulkDeleteJobResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 }
 
 func TestJobOptionFileUploadResponse(t *testing.T) {
@@ -100,6 +104,7 @@ func TestJobOptionFileUploadResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 }
 
 func TestUploadedJobInputFilesResponse(t *testing.T) {

--- a/pkg/rundeck/responses/keys.go
+++ b/pkg/rundeck/responses/keys.go
@@ -19,6 +19,10 @@ type ListKeysResponse struct {
 	Path      string                     `json:"path"`
 }
 
+func (a ListKeysResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ListKeysResponse) maxVersion() int  { return CurrentVersion }
+func (a ListKeysResponse) deprecated() bool { return false }
+
 // FromReader returns a ListKeysResponse from an io.Reader
 func (a *ListKeysResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
@@ -52,6 +56,10 @@ type ListKeysResourceResponse struct {
 	Type string          `json:"type"`
 	Path string          `json:"path"`
 }
+
+func (a ListKeysResourceResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ListKeysResourceResponse) maxVersion() int  { return CurrentVersion }
+func (a ListKeysResourceResponse) deprecated() bool { return false }
 
 // ListKeysResourceResponseTestFile is the test data for a KeyMetaResponse
 const ListKeysResourceResponseTestFile = "key_metadata.json"
@@ -88,3 +96,7 @@ type KeyMetaResponse struct {
 	RundeckContentSize string `json:"Rundeck-content-size"`
 	RundeckContentType string `json:"Rundeck-content-type"`
 }
+
+func (a KeyMetaResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a KeyMetaResponse) maxVersion() int  { return CurrentVersion }
+func (a KeyMetaResponse) deprecated() bool { return false }

--- a/pkg/rundeck/responses/keys_test.go
+++ b/pkg/rundeck/responses/keys_test.go
@@ -19,6 +19,7 @@ func TestListKeysResourceResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), kmd)
 	assert.Equal(t, "public", kmd.Meta.RundeckKeyType)
 	assert.Equal(t, "393", kmd.Meta.RundeckContentSize)
 	assert.Equal(t, "application/pgp-keys", kmd.Meta.RundeckContentType)
@@ -40,6 +41,7 @@ func TestListKeysResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), keys)
 	assert.Len(t, keys.Resources, 4)
 	assert.Equal(t, "keys", keys.Path)
 	assert.Equal(t, "directory", keys.Type)

--- a/pkg/rundeck/responses/logstorage.go
+++ b/pkg/rundeck/responses/logstorage.go
@@ -23,6 +23,10 @@ type LogStorageResponse struct {
 	MissingCount    int    `json:"missingCount"`
 }
 
+func (a LogStorageResponse) minVersion() int  { return 17 }
+func (a LogStorageResponse) maxVersion() int  { return CurrentVersion }
+func (a LogStorageResponse) deprecated() bool { return false }
+
 // FromReader returns a LogStorageResponse from an io.Reader
 func (a *LogStorageResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
@@ -58,6 +62,10 @@ type IncompleteLogStorageResponse struct {
 	Offset     int                                      `json:"offset"`
 	Executions []*IncompleteLogStorageExecutionResponse `json:"executions"`
 }
+
+func (a IncompleteLogStorageResponse) minVersion() int  { return 17 }
+func (a IncompleteLogStorageResponse) maxVersion() int  { return CurrentVersion }
+func (a IncompleteLogStorageResponse) deprecated() bool { return false }
 
 // FromReader returns a IncompleteLogStorageResponse from an io.Reader
 func (a *IncompleteLogStorageResponse) FromReader(i io.Reader) error {
@@ -99,3 +107,7 @@ type IncompleteLogStorageExecutionResponse struct {
 	} `json:"storage"`
 	Errors []string `json:"errors"`
 }
+
+func (a IncompleteLogStorageExecutionResponse) minVersion() int  { return 17 }
+func (a IncompleteLogStorageExecutionResponse) maxVersion() int  { return CurrentVersion }
+func (a IncompleteLogStorageExecutionResponse) deprecated() bool { return false }

--- a/pkg/rundeck/responses/logstorage_test.go
+++ b/pkg/rundeck/responses/logstorage_test.go
@@ -19,6 +19,7 @@ func TestLogStorageResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.True(t, obj.Enabled)
 	assert.Equal(t, "NAME", obj.PluginName)
 	assert.Equal(t, 369, obj.SucceededCount)
@@ -42,6 +43,7 @@ func TestIncompleteLogStorageResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.NotNil(t, obj.Executions)
 	assert.Len(t, obj.Executions, 1)
 	assert.Equal(t, 1, obj.Total)

--- a/pkg/rundeck/responses/paging.go
+++ b/pkg/rundeck/responses/paging.go
@@ -7,3 +7,7 @@ type PagingResponse struct {
 	Total  int `json:"total"`
 	Count  int `json:"count"`
 }
+
+func (a PagingResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a PagingResponse) maxVersion() int  { return CurrentVersion }
+func (a PagingResponse) deprecated() bool { return false }

--- a/pkg/rundeck/responses/projects.go
+++ b/pkg/rundeck/responses/projects.go
@@ -14,6 +14,10 @@ const ListProjectsResponseTestFile = "list_projects.json"
 // ListProjectsResponse represents a list projects response
 type ListProjectsResponse []*ListProjectsEntryResponse
 
+func (a ListProjectsResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ListProjectsResponse) maxVersion() int  { return CurrentVersion }
+func (a ListProjectsResponse) deprecated() bool { return false }
+
 // FromReader returns a ListProjectsResponse from an io.Reader
 func (a *ListProjectsResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
@@ -46,6 +50,10 @@ type ListProjectsEntryResponse struct {
 	Description string `json:"description,omitempty"`
 }
 
+func (a ListProjectsEntryResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ListProjectsEntryResponse) maxVersion() int  { return CurrentVersion }
+func (a ListProjectsEntryResponse) deprecated() bool { return false }
+
 // ProjectInfoResponseTestFile is test data for a ProjectInfoResponse
 const ProjectInfoResponseTestFile = "project_info.json"
 
@@ -56,6 +64,10 @@ type ProjectInfoResponse struct {
 	Description string                 `json:"description,omitempty"`
 	Config      *ProjectConfigResponse `json:"config"`
 }
+
+func (a ProjectInfoResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ProjectInfoResponse) maxVersion() int  { return CurrentVersion }
+func (a ProjectInfoResponse) deprecated() bool { return false }
 
 // FromReader returns a ProjectInfoResponse from an io.Reader
 func (a *ProjectInfoResponse) FromReader(i io.Reader) error {
@@ -85,6 +97,10 @@ func (a *ProjectInfoResponse) FromBytes(f []byte) error {
 // ProjectConfigResponse represents a projects configuration response
 type ProjectConfigResponse map[string]string
 
+func (a ProjectConfigResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ProjectConfigResponse) maxVersion() int  { return CurrentVersion }
+func (a ProjectConfigResponse) deprecated() bool { return false }
+
 // ProjectConfigResponseTestFile is test data for a ProjectConfigResponse
 const ProjectConfigResponseTestFile = "project_config.json"
 
@@ -96,6 +112,10 @@ type ProjectConfigItemResponse struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
+
+func (a ProjectConfigItemResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ProjectConfigItemResponse) maxVersion() int  { return CurrentVersion }
+func (a ProjectConfigItemResponse) deprecated() bool { return false }
 
 // FromReader returns a ProjectConfigItemResponse from an io.Reader
 func (a *ProjectConfigItemResponse) FromReader(i io.Reader) error {
@@ -132,6 +152,10 @@ type ProjectArchiveExportAsyncResponse struct {
 	Percentage int    `json:"percentage"`
 }
 
+func (a ProjectArchiveExportAsyncResponse) minVersion() int  { return 19 }
+func (a ProjectArchiveExportAsyncResponse) maxVersion() int  { return CurrentVersion }
+func (a ProjectArchiveExportAsyncResponse) deprecated() bool { return false }
+
 // FromReader returns a ProjectArchiveExportAsyncResponse from an io.Reader
 func (a *ProjectArchiveExportAsyncResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
@@ -167,6 +191,10 @@ type ProjectImportArchiveResponse struct {
 	ExecutionErrors *[]string `json:"execution_errors,omitempty"`
 	ACLErrors       *[]string `json:"acl_errors,omitempty"`
 }
+
+func (a ProjectImportArchiveResponse) minVersion() int  { return 19 }
+func (a ProjectImportArchiveResponse) maxVersion() int  { return CurrentVersion }
+func (a ProjectImportArchiveResponse) deprecated() bool { return false }
 
 // FromReader returns a ProjectImportArchiveResponse from an io.Reader
 func (a *ProjectImportArchiveResponse) FromReader(i io.Reader) error {

--- a/pkg/rundeck/responses/projects_test.go
+++ b/pkg/rundeck/responses/projects_test.go
@@ -20,6 +20,7 @@ func TestListProjectsResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Len(t, obj, 1)
 	assert.Equal(t, "[API Href]", obj[0].URL)
 	assert.Equal(t, "testproject", obj[0].Name)
@@ -39,6 +40,7 @@ func TestProjectInfoResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, "[API Href]", obj.URL)
 	assert.Equal(t, "testproject", obj.Name)
 	assert.Equal(t, "test project", obj.Description)
@@ -59,6 +61,7 @@ func TestProjectConfigItemResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, "project.ssh-connect-timeout", obj.Key)
 	assert.Equal(t, "0", obj.Value)
 }
@@ -76,6 +79,7 @@ func TestProjectArchiveExportAsyncResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, "[TOKEN]", obj.Token)
 	assert.False(t, obj.Ready)
 	assert.Equal(t, 75, obj.Percentage)
@@ -93,7 +97,7 @@ func TestProjectImportArchiveResponse(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
-
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, "successful", obj.ImportStatus)
 	assert.Nil(t, obj.Errors)
 	assert.Nil(t, obj.ExecutionErrors)
@@ -113,6 +117,7 @@ func TestProjectArchiveImportFailedResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, "failed", obj.ImportStatus)
 	assert.NotNil(t, obj.Errors)
 	assert.Len(t, *obj.Errors, 2)

--- a/pkg/rundeck/responses/resources.go
+++ b/pkg/rundeck/responses/resources.go
@@ -14,11 +14,19 @@ const ResourceCollectionResponseTestFile = "resources.json"
 // ResourceCollectionResponse represents a collection of resource response
 type ResourceCollectionResponse ResourceResponse
 
+func (a ResourceCollectionResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ResourceCollectionResponse) maxVersion() int  { return CurrentVersion }
+func (a ResourceCollectionResponse) deprecated() bool { return false }
+
 // ResourceResponseTestFile is the testdata user in testing
 const ResourceResponseTestFile = "resource.json"
 
 // ResourceResponse is a single resource in a response
 type ResourceResponse map[string]*ResourceDetailResponse
+
+func (a ResourceResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ResourceResponse) maxVersion() int  { return CurrentVersion }
+func (a ResourceResponse) deprecated() bool { return false }
 
 // ResourceDetailResponse represents a project resource response
 type ResourceDetailResponse struct {
@@ -39,57 +47,65 @@ type ResourceDetailResponse struct {
 	CustomProperties  *ArtbitraryResourcePropertiesResponse `json:",-"`
 }
 
+func (a ResourceDetailResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ResourceDetailResponse) maxVersion() int  { return CurrentVersion }
+func (a ResourceDetailResponse) deprecated() bool { return false }
+
 // ArtbitraryResourcePropertiesResponse represents custom properties in a resource response
 type ArtbitraryResourcePropertiesResponse map[string]string
 
+func (a ArtbitraryResourcePropertiesResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ArtbitraryResourcePropertiesResponse) maxVersion() int  { return CurrentVersion }
+func (a ArtbitraryResourcePropertiesResponse) deprecated() bool { return false }
+
 // FromReader returns a ResourceCollectionResponse from an io.Reader
-func (r *ResourceCollectionResponse) FromReader(i io.Reader) error {
+func (a *ResourceCollectionResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(b, r)
+	return json.Unmarshal(b, a)
 
 }
 
 // FromFile returns a ResourceCollectionResponse from a file
-func (r *ResourceCollectionResponse) FromFile(f string) error {
+func (a *ResourceCollectionResponse) FromFile(f string) error {
 	file, err := os.Open(f)
 	defer func() { _ = file.Close() }()
 	if err != nil {
 		return err
 	}
-	return r.FromReader(file)
+	return a.FromReader(file)
 }
 
 // FromBytes returns a ResourceCollectionResponse from a byte slice
-func (r *ResourceCollectionResponse) FromBytes(f []byte) error {
+func (a *ResourceCollectionResponse) FromBytes(f []byte) error {
 	file := bytes.NewReader(f)
-	return r.FromReader(file)
+	return a.FromReader(file)
 }
 
 // FromReader returns a ResourceResponse from an io.Reader
-func (r *ResourceResponse) FromReader(i io.Reader) error {
+func (a *ResourceResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(b, r)
+	return json.Unmarshal(b, a)
 
 }
 
 // FromFile returns a ResourceResponse from a file
-func (r *ResourceResponse) FromFile(f string) error {
+func (a *ResourceResponse) FromFile(f string) error {
 	file, err := os.Open(f)
 	defer func() { _ = file.Close() }()
 	if err != nil {
 		return err
 	}
-	return r.FromReader(file)
+	return a.FromReader(file)
 }
 
 // FromBytes returns a ResourceResponse from a byte slice
-func (r *ResourceResponse) FromBytes(f []byte) error {
+func (a *ResourceResponse) FromBytes(f []byte) error {
 	file := bytes.NewReader(f)
-	return r.FromReader(file)
+	return a.FromReader(file)
 }

--- a/pkg/rundeck/responses/resources_test.go
+++ b/pkg/rundeck/responses/resources_test.go
@@ -20,6 +20,7 @@ func TestResourceCollectionResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Len(t, obj, 11)
 }
 
@@ -36,6 +37,7 @@ func TestResourceResponse(t *testing.T) {
 		t.FailNow()
 	}
 	node := obj["node-0-fake"]
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, "node-0-fake", node.NodeName)
 	assert.Equal(t, "nodehost-fake", node.HostName)
 	assert.Equal(t, "stub", node.NodeExectutor)

--- a/pkg/rundeck/responses/scm.go
+++ b/pkg/rundeck/responses/scm.go
@@ -1,0 +1,9 @@
+package responses
+
+// SCMResponse is current a placeholder response for SCM
+// TODO: implement
+type SCMResponse struct{}
+
+func (s SCMResponse) minVersion() int  { return 15 }
+func (s SCMResponse) maxVersion() int  { return CurrentVersion }
+func (s SCMResponse) deprecated() bool { return false }

--- a/pkg/rundeck/responses/systeminfo.go
+++ b/pkg/rundeck/responses/systeminfo.go
@@ -9,8 +9,24 @@ import (
 )
 
 // SystemInfoResponse represents a system info response
+// http://rundeck.org/docs/api/index.html#system-info
 type SystemInfoResponse struct {
 	System *SystemsResponse `json:"system"`
+}
+
+// MinVersion is the minimum version of the API required for this response
+func (a SystemInfoResponse) MinVersion() int {
+	return 14
+}
+
+// MaxVersion is the maximum version of the API that this response supports
+func (a SystemInfoResponse) MaxVersion() int {
+	return CurrentVersion
+}
+
+// Deprecated is if a given response is deprecated
+func (a SystemInfoResponse) Deprecated() bool {
+	return false
 }
 
 // SystemInfoResponseTestFile is test data for a SystemInfoResponse

--- a/pkg/rundeck/responses/systeminfo.go
+++ b/pkg/rundeck/responses/systeminfo.go
@@ -14,20 +14,9 @@ type SystemInfoResponse struct {
 	System *SystemsResponse `json:"system"`
 }
 
-// MinVersion is the minimum version of the API required for this response
-func (a SystemInfoResponse) MinVersion() int {
-	return 14
-}
-
-// MaxVersion is the maximum version of the API that this response supports
-func (a SystemInfoResponse) MaxVersion() int {
-	return CurrentVersion
-}
-
-// Deprecated is if a given response is deprecated
-func (a SystemInfoResponse) Deprecated() bool {
-	return false
-}
+func (a SystemInfoResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a SystemInfoResponse) maxVersion() int  { return CurrentVersion }
+func (a SystemInfoResponse) deprecated() bool { return false }
 
 // SystemInfoResponseTestFile is test data for a SystemInfoResponse
 const SystemInfoResponseTestFile = "systeminfo.json"

--- a/pkg/rundeck/responses/systeminfo_test.go
+++ b/pkg/rundeck/responses/systeminfo_test.go
@@ -21,6 +21,7 @@ func TestSystemInfoResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.NotNil(t, obj.System)
 	assert.NotNil(t, obj.System.Timestamp)
 	assert.NotNil(t, obj.System.Rundeck)

--- a/pkg/rundeck/responses/toggle.go
+++ b/pkg/rundeck/responses/toggle.go
@@ -36,20 +36,9 @@ type BulkToggleResponse struct {
 	Succeeded     []BulkToggleEntryResponse `json:"succeeded"`
 }
 
-// MinVersion is the minimum version of the API required for this response
-func (a BulkToggleResponse) MinVersion() int {
-	return 14
-}
-
-// MaxVersion is the maximum version of the API that this response supports
-func (a BulkToggleResponse) MaxVersion() int {
-	return CurrentVersion
-}
-
-// Deprecated is if a given response is deprecated
-func (a BulkToggleResponse) Deprecated() bool {
-	return false
-}
+func (a BulkToggleResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a BulkToggleResponse) maxVersion() int  { return CurrentVersion }
+func (a BulkToggleResponse) deprecated() bool { return false }
 
 // BulkToggleEntryResponse represents an individual entry in a BulkToggleResponse
 type BulkToggleEntryResponse struct {
@@ -58,20 +47,9 @@ type BulkToggleEntryResponse struct {
 	Message   string `json:"message"`
 }
 
-// MinVersion is the minimum version of the API required for this response
-func (a BulkToggleEntryResponse) MinVersion() int {
-	return 14
-}
-
-// MaxVersion is the maximum version of the API that this response supports
-func (a BulkToggleEntryResponse) MaxVersion() int {
-	return CurrentVersion
-}
-
-// Deprecated is if a given response is deprecated
-func (a BulkToggleEntryResponse) Deprecated() bool {
-	return false
-}
+func (a BulkToggleEntryResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a BulkToggleEntryResponse) maxVersion() int  { return CurrentVersion }
+func (a BulkToggleEntryResponse) deprecated() bool { return false }
 
 // FromReader returns an BulkToggleResponse from an io.Reader
 func (a *BulkToggleResponse) FromReader(i io.Reader) error {
@@ -109,17 +87,6 @@ type ToggleResponse struct {
 	Success bool `json:"success"`
 }
 
-// MinVersion is the minimum version of the API required for this response
-func (a ToggleResponse) MinVersion() int {
-	return 14
-}
-
-// MaxVersion is the maximum version of the API that this response supports
-func (a ToggleResponse) MaxVersion() int {
-	return CurrentVersion
-}
-
-// Deprecated is if a given response is deprecated
-func (a ToggleResponse) Deprecated() bool {
-	return false
-}
+func (a ToggleResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (a ToggleResponse) maxVersion() int  { return CurrentVersion }
+func (a ToggleResponse) deprecated() bool { return false }

--- a/pkg/rundeck/responses/toggle.go
+++ b/pkg/rundeck/responses/toggle.go
@@ -36,11 +36,41 @@ type BulkToggleResponse struct {
 	Succeeded     []BulkToggleEntryResponse `json:"succeeded"`
 }
 
+// MinVersion is the minimum version of the API required for this response
+func (a BulkToggleResponse) MinVersion() int {
+	return 14
+}
+
+// MaxVersion is the maximum version of the API that this response supports
+func (a BulkToggleResponse) MaxVersion() int {
+	return CurrentVersion
+}
+
+// Deprecated is if a given response is deprecated
+func (a BulkToggleResponse) Deprecated() bool {
+	return false
+}
+
 // BulkToggleEntryResponse represents an individual entry in a BulkToggleResponse
 type BulkToggleEntryResponse struct {
 	ID        string `json:"id"`
 	ErrorCode string `json:"errorCode,omitempty"`
 	Message   string `json:"message"`
+}
+
+// MinVersion is the minimum version of the API required for this response
+func (a BulkToggleEntryResponse) MinVersion() int {
+	return 14
+}
+
+// MaxVersion is the maximum version of the API that this response supports
+func (a BulkToggleEntryResponse) MaxVersion() int {
+	return CurrentVersion
+}
+
+// Deprecated is if a given response is deprecated
+func (a BulkToggleEntryResponse) Deprecated() bool {
+	return false
 }
 
 // FromReader returns an BulkToggleResponse from an io.Reader
@@ -66,4 +96,30 @@ func (a *BulkToggleResponse) FromFile(f string) error {
 func (a *BulkToggleResponse) FromBytes(f []byte) error {
 	file := bytes.NewReader(f)
 	return a.FromReader(file)
+}
+
+// SuccessToggleResponseTestFile is the test data for a successful toggle
+const SuccessToggleResponseTestFile = "success.json"
+
+// FailToggleResponseTestFile is the test data for a successful toggle
+const FailToggleResponseTestFile = "failed.json"
+
+// ToggleResponse is the response for a toggled job, exeuction or schedule
+type ToggleResponse struct {
+	Success bool `json:"success"`
+}
+
+// MinVersion is the minimum version of the API required for this response
+func (a ToggleResponse) MinVersion() int {
+	return 14
+}
+
+// MaxVersion is the maximum version of the API that this response supports
+func (a ToggleResponse) MaxVersion() int {
+	return CurrentVersion
+}
+
+// Deprecated is if a given response is deprecated
+func (a ToggleResponse) Deprecated() bool {
+	return false
 }

--- a/pkg/rundeck/responses/toggle_test.go
+++ b/pkg/rundeck/responses/toggle_test.go
@@ -14,5 +14,6 @@ func TestBulkToggleResponse(t *testing.T) {
 		t.Fatal(dataErr.Error())
 	}
 	err := obj.FromBytes(data)
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.NoError(t, err)
 }

--- a/pkg/rundeck/responses/token.go
+++ b/pkg/rundeck/responses/token.go
@@ -21,20 +21,9 @@ type TokenResponse struct {
 	Duration   string    `json:"duration,omitempty"`
 }
 
-// MinVersion is the minimum version of the API required for this response
-func (t TokenResponse) MinVersion() int {
-	return 19
-}
-
-// MaxVersion is the maximum version of the API that this response supports
-func (t TokenResponse) MaxVersion() int {
-	return CurrentVersion
-}
-
-// Deprecated is if a given response is deprecated
-func (t TokenResponse) Deprecated() bool {
-	return false
-}
+func (t TokenResponse) minVersion() int  { return 19 }
+func (t TokenResponse) maxVersion() int  { return CurrentVersion }
+func (t TokenResponse) deprecated() bool { return false }
 
 // TokenResponseTestFile is test data for a TokenResponse
 const TokenResponseTestFile = "token.json"
@@ -68,20 +57,9 @@ func (t *TokenResponse) FromBytes(f []byte) error {
 // http://rundeck.org/docs/api/index.html#list-tokens
 type ListTokensResponse []*TokenResponse
 
-// MinVersion is the minimum version of the API required for this response
-func (t ListTokensResponse) MinVersion() int {
-	return 19
-}
-
-// MaxVersion is the maximum version of the API that this response supports
-func (t ListTokensResponse) MaxVersion() int {
-	return CurrentVersion
-}
-
-// Deprecated is if a given response is deprecated
-func (t ListTokensResponse) Deprecated() bool {
-	return false
-}
+func (t ListTokensResponse) minVersion() int  { return 19 }
+func (t ListTokensResponse) maxVersion() int  { return CurrentVersion }
+func (t ListTokensResponse) deprecated() bool { return false }
 
 // ListTokensResponseTestFile is test data for a TokensResponse
 const ListTokensResponseTestFile = "tokens.json"

--- a/pkg/rundeck/responses/token.go
+++ b/pkg/rundeck/responses/token.go
@@ -9,6 +9,7 @@ import (
 )
 
 // TokenResponse represents a user and token
+// http://rundeck.org/docs/api/index.html#get-a-token
 type TokenResponse struct {
 	ID         string    `json:"id,omitempty"`
 	User       string    `json:"user,omitempty"`
@@ -20,36 +21,67 @@ type TokenResponse struct {
 	Duration   string    `json:"duration,omitempty"`
 }
 
+// MinVersion is the minimum version of the API required for this response
+func (t TokenResponse) MinVersion() int {
+	return 19
+}
+
+// MaxVersion is the maximum version of the API that this response supports
+func (t TokenResponse) MaxVersion() int {
+	return CurrentVersion
+}
+
+// Deprecated is if a given response is deprecated
+func (t TokenResponse) Deprecated() bool {
+	return false
+}
+
 // TokenResponseTestFile is test data for a TokenResponse
 const TokenResponseTestFile = "token.json"
 
 // FromReader returns a TokenResponse from an io.Reader
-func (a *TokenResponse) FromReader(i io.Reader) error {
+func (t *TokenResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(b, a)
+	return json.Unmarshal(b, t)
 }
 
 // FromFile returns a TokenResponse from a file
-func (a *TokenResponse) FromFile(f string) error {
+func (t *TokenResponse) FromFile(f string) error {
 	file, err := os.Open(f)
 	defer func() { _ = file.Close() }()
 	if err != nil {
 		return err
 	}
-	return a.FromReader(file)
+	return t.FromReader(file)
 }
 
 // FromBytes returns a TokenResponse from a byte slice
-func (a *TokenResponse) FromBytes(f []byte) error {
+func (t *TokenResponse) FromBytes(f []byte) error {
 	file := bytes.NewReader(f)
-	return a.FromReader(file)
+	return t.FromReader(file)
 }
 
-// TokensResponse is a collection of `Token`
-type TokensResponse []*TokenResponse
+// ListTokensResponse is a collection of `Token`
+// http://rundeck.org/docs/api/index.html#list-tokens
+type ListTokensResponse []*TokenResponse
 
-// TokensResponseTestFile is test data for a TokensResponse
-const TokensResponseTestFile = "tokens.json"
+// MinVersion is the minimum version of the API required for this response
+func (t ListTokensResponse) MinVersion() int {
+	return 19
+}
+
+// MaxVersion is the maximum version of the API that this response supports
+func (t ListTokensResponse) MaxVersion() int {
+	return CurrentVersion
+}
+
+// Deprecated is if a given response is deprecated
+func (t ListTokensResponse) Deprecated() bool {
+	return false
+}
+
+// ListTokensResponseTestFile is test data for a TokensResponse
+const ListTokensResponseTestFile = "tokens.json"

--- a/pkg/rundeck/responses/token_test.go
+++ b/pkg/rundeck/responses/token_test.go
@@ -20,6 +20,7 @@ func TestTokenResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, "user3", obj.User)
 	assert.Equal(t, "VjkbX2zUAwnXjDIbRYFp824tF5X2N7W1", obj.Token)
 	assert.Equal(t, "c13de457-c429-4476-9acd-e1c89e3c2928", obj.ID)

--- a/pkg/rundeck/responses/user.go
+++ b/pkg/rundeck/responses/user.go
@@ -17,20 +17,9 @@ type UserProfileResponse struct {
 	Email     string `json:"email,omitempty"`
 }
 
-// MinVersion is the minimum version of the API required for this response
-func (u UserProfileResponse) MinVersion() int {
-	return 21
-}
-
-// MaxVersion is the maximum version of the API that this response supports
-func (u UserProfileResponse) MaxVersion() int {
-	return CurrentVersion
-}
-
-// Deprecated is if a given response is deprecated
-func (u UserProfileResponse) Deprecated() bool {
-	return false
-}
+func (u UserProfileResponse) minVersion() int  { return 21 }
+func (u UserProfileResponse) maxVersion() int  { return CurrentVersion }
+func (u UserProfileResponse) deprecated() bool { return false }
 
 // UserProfileResponseTestFile is test data for a UserInfoResponse
 const UserProfileResponseTestFile = "user.json"
@@ -67,20 +56,9 @@ type ListUsersResponse []*UserProfileResponse
 // ListUsersResponseTestFile is test data for a UsersInfoResponse
 const ListUsersResponseTestFile = "users.json"
 
-// MinVersion is the minimum version of the API required for this response
-func (u ListUsersResponse) MinVersion() int {
-	return 21
-}
-
-// MaxVersion is the maximum version of the API that this response supports
-func (u ListUsersResponse) MaxVersion() int {
-	return CurrentVersion
-}
-
-// Deprecated is if a given response is deprecated
-func (u ListUsersResponse) Deprecated() bool {
-	return false
-}
+func (u ListUsersResponse) minVersion() int  { return 21 }
+func (u ListUsersResponse) maxVersion() int  { return CurrentVersion }
+func (u ListUsersResponse) deprecated() bool { return false }
 
 // FromReader returns a UsersInfoResponse from an io.Reader
 func (u *ListUsersResponse) FromReader(i io.Reader) error {

--- a/pkg/rundeck/responses/user.go
+++ b/pkg/rundeck/responses/user.go
@@ -8,69 +8,101 @@ import (
 	"os"
 )
 
-// UserInfoResponse represents a user info response
-type UserInfoResponse struct {
+// UserProfileResponse represents a user info response
+// http://rundeck.org/docs/api/index.html#get-user-profile
+type UserProfileResponse struct {
 	Login     string `json:"login"`
 	FirstName string `json:"firstName,omitempty"`
 	LastName  string `json:"lastName,omitempty"`
 	Email     string `json:"email,omitempty"`
 }
 
-// UserInfoResponseTestFile is test data for a UserInfoResponse
-const UserInfoResponseTestFile = "user.json"
+// MinVersion is the minimum version of the API required for this response
+func (u UserProfileResponse) MinVersion() int {
+	return 21
+}
+
+// MaxVersion is the maximum version of the API that this response supports
+func (u UserProfileResponse) MaxVersion() int {
+	return CurrentVersion
+}
+
+// Deprecated is if a given response is deprecated
+func (u UserProfileResponse) Deprecated() bool {
+	return false
+}
+
+// UserProfileResponseTestFile is test data for a UserInfoResponse
+const UserProfileResponseTestFile = "user.json"
 
 // FromReader returns a UserInfoResponse from an io.Reader
-func (a *UserInfoResponse) FromReader(i io.Reader) error {
+func (u *UserProfileResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(b, a)
+	return json.Unmarshal(b, u)
 }
 
 // FromFile returns a UserInfoResponse from a file
-func (a *UserInfoResponse) FromFile(f string) error {
+func (u *UserProfileResponse) FromFile(f string) error {
 	file, err := os.Open(f)
 	defer func() { _ = file.Close() }()
 	if err != nil {
 		return err
 	}
-	return a.FromReader(file)
+	return u.FromReader(file)
 }
 
 // FromBytes returns a UserInfoResponse from a byte slice
-func (a *UserInfoResponse) FromBytes(f []byte) error {
+func (u *UserProfileResponse) FromBytes(f []byte) error {
 	file := bytes.NewReader(f)
-	return a.FromReader(file)
+	return u.FromReader(file)
 }
 
-// UsersInfoResponse is a collection of `UserInfo`
-type UsersInfoResponse []*UserInfoResponse
+// ListUsersResponse is a collection of `UserInfo`
+// http://rundeck.org/docs/api/index.html#list-users
+type ListUsersResponse []*UserProfileResponse
 
-// UsersInfoResponseTestFile is test data for a UsersInfoResponse
-const UsersInfoResponseTestFile = "users.json"
+// ListUsersResponseTestFile is test data for a UsersInfoResponse
+const ListUsersResponseTestFile = "users.json"
+
+// MinVersion is the minimum version of the API required for this response
+func (u ListUsersResponse) MinVersion() int {
+	return 21
+}
+
+// MaxVersion is the maximum version of the API that this response supports
+func (u ListUsersResponse) MaxVersion() int {
+	return CurrentVersion
+}
+
+// Deprecated is if a given response is deprecated
+func (u ListUsersResponse) Deprecated() bool {
+	return false
+}
 
 // FromReader returns a UsersInfoResponse from an io.Reader
-func (a *UsersInfoResponse) FromReader(i io.Reader) error {
+func (u *ListUsersResponse) FromReader(i io.Reader) error {
 	b, err := ioutil.ReadAll(i)
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(b, a)
+	return json.Unmarshal(b, u)
 }
 
 // FromFile returns a UsersInfoResponse from a file
-func (a *UsersInfoResponse) FromFile(f string) error {
+func (u *ListUsersResponse) FromFile(f string) error {
 	file, err := os.Open(f)
 	defer func() { _ = file.Close() }()
 	if err != nil {
 		return err
 	}
-	return a.FromReader(file)
+	return u.FromReader(file)
 }
 
 // FromBytes returns a UsersInfoResponse from a byte slice
-func (a *UsersInfoResponse) FromBytes(f []byte) error {
+func (u *ListUsersResponse) FromBytes(f []byte) error {
 	file := bytes.NewReader(f)
-	return a.FromReader(file)
+	return u.FromReader(file)
 }

--- a/pkg/rundeck/responses/user_test.go
+++ b/pkg/rundeck/responses/user_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestUserInfoResponse(t *testing.T) {
-	obj := UserInfoResponse{}
-	data, dataErr := testdata.GetBytes(UserInfoResponseTestFile)
+	obj := UserProfileResponse{}
+	data, dataErr := testdata.GetBytes(UserProfileResponseTestFile)
 	if dataErr != nil {
 		t.Error(dataErr.Error())
 		t.FailNow()
@@ -27,8 +27,8 @@ func TestUserInfoResponse(t *testing.T) {
 }
 
 func TestUsersInfoResponse(t *testing.T) {
-	obj := UsersInfoResponse{}
-	data, dataErr := testdata.GetBytes(UsersInfoResponseTestFile)
+	obj := ListUsersResponse{}
+	data, dataErr := testdata.GetBytes(ListUsersResponseTestFile)
 	if dataErr != nil {
 		t.Error(dataErr.Error())
 		t.FailNow()

--- a/pkg/rundeck/responses/user_test.go
+++ b/pkg/rundeck/responses/user_test.go
@@ -20,6 +20,7 @@ func TestUserInfoResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Equal(t, "admin", obj.Login)
 	assert.Equal(t, "Admin", obj.FirstName)
 	assert.Equal(t, "McAdmin", obj.LastName)
@@ -39,6 +40,7 @@ func TestUsersInfoResponse(t *testing.T) {
 		t.FailNow()
 	}
 
+	assert.Implements(t, (*VersionedResponse)(nil), obj)
 	assert.Len(t, obj, 2)
 	assert.NotNil(t, obj[0])
 	assert.NotNil(t, obj[1])

--- a/pkg/rundeck/responses/versioned_response.go
+++ b/pkg/rundeck/responses/versioned_response.go
@@ -22,3 +22,13 @@ func GetMaxVersionFor(a VersionedResponse) int { return a.maxVersion() }
 
 // IsDeprecated indicates if a response is deprecated or not
 func IsDeprecated(a VersionedResponse) bool { return a.deprecated() }
+
+// GenericVersionedResponse is for version checking
+// Some operations don't have a response (think DELETE or PUT)
+// but we still want to do a version check on ALL functions anyway
+// This response simply responds to that
+type GenericVersionedResponse struct{}
+
+func (g GenericVersionedResponse) minVersion() int  { return AbsoluteMinimumVersion }
+func (g GenericVersionedResponse) maxVersion() int  { return CurrentVersion }
+func (g GenericVersionedResponse) deprecated() bool { return false }

--- a/pkg/rundeck/responses/versioned_response.go
+++ b/pkg/rundeck/responses/versioned_response.go
@@ -2,9 +2,9 @@ package responses
 
 // VersionedResponse is an interface for a Rundeck Response that supports versioning information
 type VersionedResponse interface {
-	MinVersion() int
-	MaxVersion() int
-	Deprecated() bool
+	minVersion() int
+	maxVersion() int
+	deprecated() bool
 }
 
 // AbsoluteMinimumVersion is the absolute minimum version this library will support
@@ -15,16 +15,10 @@ const AbsoluteMinimumVersion = 14
 const CurrentVersion = 21
 
 // GetMinVersionFor gets the minimum api version required for a response
-func GetMinVersionFor(a VersionedResponse) int {
-	return a.MinVersion()
-}
+func GetMinVersionFor(a VersionedResponse) int { return a.minVersion() }
 
 // GetMaxVersionFor gets the maximum api version required for a response
-func GetMaxVersionFor(a VersionedResponse) int {
-	return a.MaxVersion()
-}
+func GetMaxVersionFor(a VersionedResponse) int { return a.maxVersion() }
 
 // IsDeprecated indicates if a response is deprecated or not
-func IsDeprecated(a VersionedResponse) bool {
-	return a.Deprecated()
-}
+func IsDeprecated(a VersionedResponse) bool { return a.deprecated() }

--- a/pkg/rundeck/responses/versioned_response.go
+++ b/pkg/rundeck/responses/versioned_response.go
@@ -1,0 +1,30 @@
+package responses
+
+// VersionedResponse is an interface for a Rundeck Response that supports versioning information
+type VersionedResponse interface {
+	MinVersion() int
+	MaxVersion() int
+	Deprecated() bool
+}
+
+// AbsoluteMinimumVersion is the absolute minimum version this library will support
+// We set this to `14` as that was the first version of the rundeck API to support JSON
+const AbsoluteMinimumVersion = 14
+
+// CurrentVersion is the current version of the API that this library is tested against
+const CurrentVersion = 21
+
+// GetMinVersionFor gets the minimum api version required for a response
+func GetMinVersionFor(a VersionedResponse) int {
+	return a.MinVersion()
+}
+
+// GetMaxVersionFor gets the maximum api version required for a response
+func GetMaxVersionFor(a VersionedResponse) int {
+	return a.MaxVersion()
+}
+
+// IsDeprecated indicates if a response is deprecated or not
+func IsDeprecated(a VersionedResponse) bool {
+	return a.Deprecated()
+}

--- a/pkg/rundeck/schedule.go
+++ b/pkg/rundeck/schedule.go
@@ -12,7 +12,9 @@ import (
 // DisableSchedule disables a scheduled job
 // http://rundeck.org/docs/api/index.html#disable-scheduling-for-a-job
 func (c *Client) DisableSchedule(id string) (bool, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.ToggleResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.ToggleResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return false, err
 	}
 	t := &responses.ToggleResponse{}
@@ -29,7 +31,9 @@ func (c *Client) DisableSchedule(id string) (bool, error) {
 // EnableSchedule enables a scheduled job
 // http://rundeck.org/docs/api/index.html#enable-scheduling-for-a-job
 func (c *Client) EnableSchedule(id string) (bool, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.ToggleResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.ToggleResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return false, err
 	}
 	t := &responses.ToggleResponse{}
@@ -46,7 +50,9 @@ func (c *Client) EnableSchedule(id string) (bool, error) {
 // BulkEnableSchedule enables scheduled jobs in bulk
 // http://rundeck.org/docs/api/index.html#bulk-toggle-job-schedules
 func (c *Client) BulkEnableSchedule(ids ...string) (*responses.BulkToggleResponse, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.BulkToggleResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.BulkToggleResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return nil, err
 	}
 	req := &requests.BulkToggleRequest{
@@ -70,7 +76,9 @@ func (c *Client) BulkEnableSchedule(ids ...string) (*responses.BulkToggleRespons
 // BulkDisableSchedule enables scheduled jobs in bulk
 // http://rundeck.org/docs/api/index.html#bulk-toggle-job-schedules
 func (c *Client) BulkDisableSchedule(ids ...string) (*responses.BulkToggleResponse, error) {
-	if _, err := c.hasRequiredAPIVersion(minJSONSupportedAPIVersion, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.BulkToggleResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.BulkToggleResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return nil, err
 	}
 	req := &requests.BulkToggleRequest{

--- a/pkg/rundeck/schedule.go
+++ b/pkg/rundeck/schedule.go
@@ -12,9 +12,7 @@ import (
 // DisableSchedule disables a scheduled job
 // http://rundeck.org/docs/api/index.html#disable-scheduling-for-a-job
 func (c *Client) DisableSchedule(id string) (bool, error) {
-	minVer := responses.GetMinVersionFor(responses.ToggleResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.ToggleResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ToggleResponse{}); err != nil {
 		return false, err
 	}
 	t := &responses.ToggleResponse{}
@@ -31,9 +29,7 @@ func (c *Client) DisableSchedule(id string) (bool, error) {
 // EnableSchedule enables a scheduled job
 // http://rundeck.org/docs/api/index.html#enable-scheduling-for-a-job
 func (c *Client) EnableSchedule(id string) (bool, error) {
-	minVer := responses.GetMinVersionFor(responses.ToggleResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.ToggleResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ToggleResponse{}); err != nil {
 		return false, err
 	}
 	t := &responses.ToggleResponse{}
@@ -50,9 +46,7 @@ func (c *Client) EnableSchedule(id string) (bool, error) {
 // BulkEnableSchedule enables scheduled jobs in bulk
 // http://rundeck.org/docs/api/index.html#bulk-toggle-job-schedules
 func (c *Client) BulkEnableSchedule(ids ...string) (*responses.BulkToggleResponse, error) {
-	minVer := responses.GetMinVersionFor(responses.BulkToggleResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.BulkToggleResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.BulkToggleResponse{}); err != nil {
 		return nil, err
 	}
 	req := &requests.BulkToggleRequest{
@@ -76,9 +70,7 @@ func (c *Client) BulkEnableSchedule(ids ...string) (*responses.BulkToggleRespons
 // BulkDisableSchedule enables scheduled jobs in bulk
 // http://rundeck.org/docs/api/index.html#bulk-toggle-job-schedules
 func (c *Client) BulkDisableSchedule(ids ...string) (*responses.BulkToggleResponse, error) {
-	minVer := responses.GetMinVersionFor(responses.BulkToggleResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.BulkToggleResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.BulkToggleResponse{}); err != nil {
 		return nil, err
 	}
 	req := &requests.BulkToggleRequest{

--- a/pkg/rundeck/scm.go
+++ b/pkg/rundeck/scm.go
@@ -1,11 +1,15 @@
 package rundeck
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/lusis/go-rundeck/pkg/rundeck/responses"
+)
 
 // ListSCMPlugins list the available plugins for the specified integration
 // http://rundeck.org/docs/api/index.html#list-scm-plugins
 func (c *Client) ListSCMPlugins() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -14,7 +18,7 @@ func (c *Client) ListSCMPlugins() error {
 // GetSCMPluginInputFields List the input fields for a specific plugin.
 // http://rundeck.org/docs/api/index.html#get-scm-plugin-input-fields
 func (c *Client) GetSCMPluginInputFields() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -23,7 +27,7 @@ func (c *Client) GetSCMPluginInputFields() error {
 // SetupSCMPluginForProject configures and enables a plugin for a project
 // http://rundeck.org/docs/api/index.html#setup-scm-plugin-for-a-project
 func (c *Client) SetupSCMPluginForProject() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -32,7 +36,7 @@ func (c *Client) SetupSCMPluginForProject() error {
 // EnableSCMPluginForProject enables a plugin for a project
 // http://rundeck.org/docs/api/index.html#enable-scm-plugin-for-a-project
 func (c *Client) EnableSCMPluginForProject() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -41,7 +45,7 @@ func (c *Client) EnableSCMPluginForProject() error {
 // DisableSCMPluginForProject disables a plugin for a project
 // http://rundeck.org/docs/api/index.html#enable-scm-plugin-for-a-project
 func (c *Client) DisableSCMPluginForProject() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -50,7 +54,7 @@ func (c *Client) DisableSCMPluginForProject() error {
 // GetProjectSCMStatus Get the SCM plugin status and available actions for the project.
 // http://rundeck.org/docs/api/index.html#get-project-scm-status
 func (c *Client) GetProjectSCMStatus() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -59,7 +63,7 @@ func (c *Client) GetProjectSCMStatus() error {
 // GetProjectSCMConfig Get the configuration properties for the current plugin.
 // http://rundeck.org/docs/api/index.html#get-project-scm-config
 func (c *Client) GetProjectSCMConfig() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -68,7 +72,7 @@ func (c *Client) GetProjectSCMConfig() error {
 // GetProjectSCMActionInputFields Get the input fields and selectable items for a specific action.
 // http://rundeck.org/docs/api/index.html#get-project-scm-action-input-fields
 func (c *Client) GetProjectSCMActionInputFields() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -77,7 +81,7 @@ func (c *Client) GetProjectSCMActionInputFields() error {
 // PerformProjectSCMAction Perform the action for the SCM integration plugin, with a set of input parameters, selected Jobs, or Items, or Items to delete.
 // http://rundeck.org/docs/api/index.html#perform-project-scm-action
 func (c *Client) PerformProjectSCMAction() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -86,7 +90,7 @@ func (c *Client) PerformProjectSCMAction() error {
 // GetJobSCMStatus gets a job's scm status
 // http://rundeck.org/docs/api/index.html#get-job-scm-status
 func (c *Client) GetJobSCMStatus() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -95,7 +99,7 @@ func (c *Client) GetJobSCMStatus() error {
 // GetJobSCMDiff Retrieve the file diff for the Job, if there are changes for the integration.
 // http://rundeck.org/docs/api/index.html#get-job-scm-diff
 func (c *Client) GetJobSCMDiff() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -104,7 +108,7 @@ func (c *Client) GetJobSCMDiff() error {
 // GetJobSCMActionInputFields Get the input fields and selectable items for a specific action for a job.
 // http://rundeck.org/docs/api/index.html#get-project-scm-action-input-fields
 func (c *Client) GetJobSCMActionInputFields() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")
@@ -113,7 +117,7 @@ func (c *Client) GetJobSCMActionInputFields() error {
 // PerformJobSCMAction Perform the action for the SCM integration plugin, with a set of input parameters, selected Jobs, or Items, or Items to delete.
 // http://rundeck.org/docs/api/index.html#perform-project-scm-action
 func (c *Client) PerformJobSCMAction() error {
-	if _, err := c.hasRequiredAPIVersion(15, maxRundeckVersionInt); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SCMResponse{}); err != nil {
 		return err
 	}
 	return fmt.Errorf("not yet implemented")

--- a/pkg/rundeck/system_info.go
+++ b/pkg/rundeck/system_info.go
@@ -13,9 +13,7 @@ type SystemInfo responses.SystemInfoResponse
 // GetSystemInfo gets system information from the rundeck server
 // http://rundeck.org/docs/api/index.html#system-info
 func (c *Client) GetSystemInfo() (*SystemInfo, error) {
-	minVer := responses.GetMinVersionFor(responses.SystemInfoResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.SystemInfoResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.SystemInfoResponse{}); err != nil {
 		return nil, err
 	}
 	ls := SystemInfo{}

--- a/pkg/rundeck/system_info.go
+++ b/pkg/rundeck/system_info.go
@@ -13,7 +13,9 @@ type SystemInfo responses.SystemInfoResponse
 // GetSystemInfo gets system information from the rundeck server
 // http://rundeck.org/docs/api/index.html#system-info
 func (c *Client) GetSystemInfo() (*SystemInfo, error) {
-	if _, err := c.hasRequiredAPIVersion(14, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.SystemInfoResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.SystemInfoResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return nil, err
 	}
 	ls := SystemInfo{}

--- a/pkg/rundeck/tokens.go
+++ b/pkg/rundeck/tokens.go
@@ -39,9 +39,7 @@ func TokenRoles(roles ...string) TokenOption {
 // ListTokens gets all tokens for the current user
 // http://rundeck.org/docs/api/index.html#list-tokens
 func (c *Client) ListTokens() (*Tokens, error) {
-	minVer := responses.GetMinVersionFor(responses.ListTokensResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.ListTokensResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ListTokensResponse{}); err != nil {
 		return nil, err
 	}
 	tokens := Tokens{}
@@ -59,9 +57,7 @@ func (c *Client) ListTokens() (*Tokens, error) {
 // ListTokensForUser gets the api tokens for a user
 // http://rundeck.org/docs/api/index.html#list-tokens
 func (c *Client) ListTokensForUser(user string) ([]*Token, error) {
-	minVer := responses.GetMinVersionFor(responses.ListTokensResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.ListTokensResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ListTokensResponse{}); err != nil {
 		return nil, err
 	}
 	data, err := c.httpGet("tokens/"+user, requestJSON(), requestExpects(200))
@@ -79,9 +75,7 @@ func (c *Client) ListTokensForUser(user string) ([]*Token, error) {
 // GetToken gets a token
 // http://rundeck.org/docs/api/index.html#get-a-token
 func (c *Client) GetToken(tokenID string) (*Token, error) {
-	minVer := responses.GetMinVersionFor(responses.TokenResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.TokenResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.TokenResponse{}); err != nil {
 		return nil, err
 	}
 
@@ -100,9 +94,7 @@ func (c *Client) GetToken(tokenID string) (*Token, error) {
 // CreateToken creates a token
 // http://rundeck.org/docs/api/index.html#create-a-token
 func (c *Client) CreateToken(u string, opts ...TokenOption) (*Token, error) {
-	minVer := responses.GetMinVersionFor(responses.TokenResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.TokenResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.TokenResponse{}); err != nil {
 		return nil, err
 	}
 	tokenRequest := &Token{}
@@ -131,9 +123,7 @@ func (c *Client) CreateToken(u string, opts ...TokenOption) (*Token, error) {
 // DeleteToken deletes a token
 // http://rundeck.org/docs/api/index.html#delete-a-token
 func (c *Client) DeleteToken(token string) error {
-	minVer := responses.GetMinVersionFor(responses.TokenResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.TokenResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.TokenResponse{}); err != nil {
 		return err
 	}
 	url := fmt.Sprintf("token/%s", token)

--- a/pkg/rundeck/tokens.go
+++ b/pkg/rundeck/tokens.go
@@ -14,6 +14,9 @@ type Token struct {
 	responses.TokenResponse
 }
 
+// Tokens is a collection of Token
+type Tokens responses.ListTokensResponse
+
 // TokenOption is a type for options in creating new tokens
 type TokenOption func(*Token) error
 
@@ -35,11 +38,13 @@ func TokenRoles(roles ...string) TokenOption {
 
 // ListTokens gets all tokens for the current user
 // http://rundeck.org/docs/api/index.html#list-tokens
-func (c *Client) ListTokens() ([]*Token, error) {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+func (c *Client) ListTokens() (*Tokens, error) {
+	minVer := responses.GetMinVersionFor(responses.ListTokensResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.ListTokensResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return nil, err
 	}
-	tokens := make([]*Token, 0)
+	tokens := Tokens{}
 	data, err := c.httpGet("tokens", requestJSON(), requestExpects(200))
 	if err != nil {
 		return nil, err
@@ -48,12 +53,17 @@ func (c *Client) ListTokens() ([]*Token, error) {
 	if jsonErr != nil {
 		return nil, &UnmarshalError{msg: multierror.Append(errDecoding, jsonErr).Error()}
 	}
-	return tokens, nil
+	return &tokens, nil
 }
 
 // ListTokensForUser gets the api tokens for a user
 // http://rundeck.org/docs/api/index.html#list-tokens
 func (c *Client) ListTokensForUser(user string) ([]*Token, error) {
+	minVer := responses.GetMinVersionFor(responses.ListTokensResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.ListTokensResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+		return nil, err
+	}
 	data, err := c.httpGet("tokens/"+user, requestJSON(), requestExpects(200))
 	if err != nil {
 		return nil, err
@@ -69,9 +79,12 @@ func (c *Client) ListTokensForUser(user string) ([]*Token, error) {
 // GetToken gets a token
 // http://rundeck.org/docs/api/index.html#get-a-token
 func (c *Client) GetToken(tokenID string) (*Token, error) {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.TokenResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.TokenResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return nil, err
 	}
+
 	data, err := c.httpGet("token/"+tokenID, requestJSON(), requestExpects(200))
 	if err != nil {
 		return nil, err
@@ -87,7 +100,9 @@ func (c *Client) GetToken(tokenID string) (*Token, error) {
 // CreateToken creates a token
 // http://rundeck.org/docs/api/index.html#create-a-token
 func (c *Client) CreateToken(u string, opts ...TokenOption) (*Token, error) {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.TokenResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.TokenResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return nil, err
 	}
 	tokenRequest := &Token{}
@@ -116,7 +131,9 @@ func (c *Client) CreateToken(u string, opts ...TokenOption) (*Token, error) {
 // DeleteToken deletes a token
 // http://rundeck.org/docs/api/index.html#delete-a-token
 func (c *Client) DeleteToken(token string) error {
-	if _, err := c.hasRequiredAPIVersion(19, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.TokenResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.TokenResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return err
 	}
 	url := fmt.Sprintf("token/%s", token)

--- a/pkg/rundeck/tokens_test.go
+++ b/pkg/rundeck/tokens_test.go
@@ -17,7 +17,7 @@ func testFailedTokenOption() TokenOption {
 }
 
 func TestGetTokens(t *testing.T) {
-	jsonfile, err := testdata.GetBytes(responses.TokensResponseTestFile)
+	jsonfile, err := testdata.GetBytes(responses.ListTokensResponseTestFile)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -28,14 +28,15 @@ func TestGetTokens(t *testing.T) {
 	}
 	s, err := client.ListTokens()
 	assert.NoError(t, err)
-	assert.Len(t, s, 4)
-	assert.Equal(t, "user3", s[0].User)
-	assert.Equal(t, "ece75ac8-2791-442e-b179-a9907d83fd05", s[0].ID)
-	assert.Equal(t, "user3", s[0].Creator)
-	assert.Len(t, s[0].Roles, 2)
-	assert.Equal(t, "DEV_99", s[0].Roles[0])
-	assert.False(t, s[0].Expired)
-	assert.NotEmpty(t, s[0].Expiration)
+	assert.Len(t, (*s), 4)
+	assert.Equal(t, "user3", (*s)[0].User)
+	assert.Equal(t, "ece75ac8-2791-442e-b179-a9907d83fd05", (*s)[0].ID)
+	assert.Equal(t, "user3", (*s)[0].Creator)
+	roles := (*s)[0].Roles
+	assert.Len(t, roles, 2)
+	assert.Equal(t, "DEV_99", roles[0])
+	assert.False(t, (*s)[0].Expired)
+	assert.NotEmpty(t, (*s)[0].Expiration)
 
 }
 
@@ -110,7 +111,7 @@ func TestGetTokenInvalidJSON(t *testing.T) {
 }
 
 func TestGetUserTokens(t *testing.T) {
-	jsonfile, err := testdata.GetBytes(responses.TokensResponseTestFile)
+	jsonfile, err := testdata.GetBytes(responses.ListTokensResponseTestFile)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/rundeck/user.go
+++ b/pkg/rundeck/user.go
@@ -10,18 +10,23 @@ import (
 )
 
 // User represents a user in rundeck
-type User responses.UserInfoResponse
+type User responses.UserProfileResponse
+
+// Users represents a collection of users
+type Users responses.ListUsersResponse
 
 // ListUsers returns all rundeck users
 // http://rundeck.org/docs/api/index.html#list-users
-func (c *Client) ListUsers() ([]*User, error) {
-	if _, err := c.hasRequiredAPIVersion(21, maxRundeckVersionInt); err != nil {
+func (c *Client) ListUsers() (*Users, error) {
+	minVer := responses.GetMinVersionFor(responses.ListUsersResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.ListUsersResponse{})
+	users := &Users{}
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return nil, err
 	}
-	var users []*User
 	res, err := c.httpGet("user/list", requestJSON(), requestExpects(200))
 	if err != nil {
-		return users, err
+		return nil, err
 	}
 	if jsonErr := json.Unmarshal(res, &users); jsonErr != nil {
 		return nil, &UnmarshalError{msg: multierror.Append(errDecoding, jsonErr).Error()}
@@ -32,7 +37,9 @@ func (c *Client) ListUsers() ([]*User, error) {
 // GetCurrentUserProfile returns information about the current user
 // http://rundeck.org/docs/api/index.html#get-user-profile
 func (c *Client) GetCurrentUserProfile() (*User, error) {
-	if _, err := c.hasRequiredAPIVersion(21, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.UserProfileResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.UserProfileResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return nil, err
 	}
 	user := &User{}
@@ -49,7 +56,9 @@ func (c *Client) GetCurrentUserProfile() (*User, error) {
 // GetUserProfile returns information about the named user - requires admin privileges
 // http://rundeck.org/docs/api/index.html#get-another-user-profile
 func (c *Client) GetUserProfile(login string) (*User, error) {
-	if _, err := c.hasRequiredAPIVersion(21, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.UserProfileResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.UserProfileResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return nil, err
 	}
 	user := &User{}
@@ -66,7 +75,9 @@ func (c *Client) GetUserProfile(login string) (*User, error) {
 // ModifyUserProfile updates a user
 // http://rundeck.org/docs/api/index.html#modify-user-profile
 func (c *Client) ModifyUserProfile(u *User) (*User, error) {
-	if _, err := c.hasRequiredAPIVersion(21, maxRundeckVersionInt); err != nil {
+	minVer := responses.GetMinVersionFor(responses.UserProfileResponse{})
+	maxVer := responses.GetMaxVersionFor(responses.UserProfileResponse{})
+	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
 		return nil, err
 	}
 	currentUser, currentUserErr := c.GetCurrentUserProfile()

--- a/pkg/rundeck/user.go
+++ b/pkg/rundeck/user.go
@@ -18,12 +18,11 @@ type Users responses.ListUsersResponse
 // ListUsers returns all rundeck users
 // http://rundeck.org/docs/api/index.html#list-users
 func (c *Client) ListUsers() (*Users, error) {
-	minVer := responses.GetMinVersionFor(responses.ListUsersResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.ListUsersResponse{})
-	users := &Users{}
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.ListUsersResponse{}); err != nil {
 		return nil, err
 	}
+	users := &Users{}
+
 	res, err := c.httpGet("user/list", requestJSON(), requestExpects(200))
 	if err != nil {
 		return nil, err
@@ -37,9 +36,7 @@ func (c *Client) ListUsers() (*Users, error) {
 // GetCurrentUserProfile returns information about the current user
 // http://rundeck.org/docs/api/index.html#get-user-profile
 func (c *Client) GetCurrentUserProfile() (*User, error) {
-	minVer := responses.GetMinVersionFor(responses.UserProfileResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.UserProfileResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.UserProfileResponse{}); err != nil {
 		return nil, err
 	}
 	user := &User{}
@@ -56,9 +53,7 @@ func (c *Client) GetCurrentUserProfile() (*User, error) {
 // GetUserProfile returns information about the named user - requires admin privileges
 // http://rundeck.org/docs/api/index.html#get-another-user-profile
 func (c *Client) GetUserProfile(login string) (*User, error) {
-	minVer := responses.GetMinVersionFor(responses.UserProfileResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.UserProfileResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.UserProfileResponse{}); err != nil {
 		return nil, err
 	}
 	user := &User{}
@@ -75,9 +70,7 @@ func (c *Client) GetUserProfile(login string) (*User, error) {
 // ModifyUserProfile updates a user
 // http://rundeck.org/docs/api/index.html#modify-user-profile
 func (c *Client) ModifyUserProfile(u *User) (*User, error) {
-	minVer := responses.GetMinVersionFor(responses.UserProfileResponse{})
-	maxVer := responses.GetMaxVersionFor(responses.UserProfileResponse{})
-	if _, err := c.hasRequiredAPIVersion(minVer, maxVer); err != nil {
+	if err := c.checkRequiredAPIVersion(responses.UserProfileResponse{}); err != nil {
 		return nil, err
 	}
 	currentUser, currentUserErr := c.GetCurrentUserProfile()

--- a/pkg/rundeck/users_test.go
+++ b/pkg/rundeck/users_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGetUsers(t *testing.T) {
-	jsonfile, err := testdata.GetBytes(responses.UsersInfoResponseTestFile)
+	jsonfile, err := testdata.GetBytes(responses.ListUsersResponseTestFile)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -22,7 +22,7 @@ func TestGetUsers(t *testing.T) {
 	s, err := client.ListUsers()
 	assert.NoError(t, err)
 	assert.NotNil(t, s)
-	assert.Len(t, s, 2)
+	assert.Len(t, *s, 2)
 }
 
 func TestGetUsersJSONError(t *testing.T) {
@@ -48,7 +48,7 @@ func TestGetUsersInvalidStatus(t *testing.T) {
 }
 
 func TestGetUserInfo(t *testing.T) {
-	jsonfile, err := testdata.GetBytes(responses.UserInfoResponseTestFile)
+	jsonfile, err := testdata.GetBytes(responses.UserProfileResponseTestFile)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -89,7 +89,7 @@ func TestGetUserInfoInvalidStatus(t *testing.T) {
 }
 
 func TestGetCurrentUserInfo(t *testing.T) {
-	jsonfile, err := testdata.GetBytes(responses.UserInfoResponseTestFile)
+	jsonfile, err := testdata.GetBytes(responses.UserProfileResponseTestFile)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/rundeck/version.go
+++ b/pkg/rundeck/version.go
@@ -3,16 +3,20 @@ package rundeck
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/lusis/go-rundeck/pkg/rundeck/responses"
 )
 
-func (c *Client) hasRequiredAPIVersion(min, max int) (bool, error) {
+func (c *Client) checkRequiredAPIVersion(r responses.VersionedResponse) error {
 	reqVersion, err := strconv.Atoi(c.Config.APIVersion)
 	if err != nil {
-		return false, err
+		return err
 	}
+	min := responses.GetMinVersionFor(r)
+	max := responses.GetMaxVersionFor(r)
 	if reqVersion >= min && reqVersion <= max {
-		return true, nil
+		return nil
 	}
-	return false, fmt.Errorf("Requested API version (%d) does not meet the requirements for this api call (min: %d, max: %d)",
+	return fmt.Errorf("Requested API version (%d) does not meet the requirements for this api call (min: %d, max: %d)",
 		reqVersion, min, max)
 }


### PR DESCRIPTION
This migrates responsibility to for all versioning of responses to the responses package.  Higher level packages that use responses can now call `responses.GetMinVersionFor` and `responses.GetMaxVersionFor`

Responses must satisfy the `VersionedResponse` interface:

```go
type VersionedResponse interface {
	minVersion() int
	maxVersion() int
	deprecated() bool
}
```