### PR TITLE
Adhoc support

### DIFF
--- a/cmd/rundeck/cmds/adhoc.go
+++ b/cmd/rundeck/cmds/adhoc.go
@@ -24,5 +24,6 @@ func adHocCommands() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&adHocNodeKeepGoing, "keep-going", false, "keep going on failure")
 	cmd.AddCommand(runAdHocCmdCommand())
 	cmd.AddCommand(runAdHocScriptCommand())
+	cmd.AddCommand(runAdHocURLCommand())
 	return cmd
 }

--- a/cmd/rundeck/cmds/adhoc.go
+++ b/cmd/rundeck/cmds/adhoc.go
@@ -1,0 +1,28 @@
+package cmds
+
+import "github.com/spf13/cobra"
+
+var (
+	adHocAsUser            string
+	adHocFilter            string
+	adHocNodeThreadCount   int
+	adHocNodeKeepGoing     bool
+	adHocScriptInterpreter string
+	adHocArgString         string
+	adHocArgsQuoted        bool
+	adHocFileExtension     string
+)
+
+func adHocCommands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "adhoc",
+		Short: "run adhoc commands, scripts and scripts from urls against a project",
+	}
+	cmd.PersistentFlags().StringVar(&adHocAsUser, "as-user", "", "rundeck user to run as")
+	cmd.PersistentFlags().StringVar(&adHocFilter, "filter", "", "rundeck filter to use")
+	cmd.PersistentFlags().IntVar(&adHocNodeThreadCount, "thread-count", 1, "node thread count")
+	cmd.PersistentFlags().BoolVar(&adHocNodeKeepGoing, "keep-going", false, "keep going on failure")
+	cmd.AddCommand(runAdHocCmdCommand())
+	cmd.AddCommand(runAdHocScriptCommand())
+	return cmd
+}

--- a/cmd/rundeck/cmds/get_execution.go
+++ b/cmd/rundeck/cmds/get_execution.go
@@ -25,7 +25,7 @@ func getExecutionFunc(cmd *cobra.Command, args []string) error {
 	})
 	var dateEnded string
 	if data.DateEnded.Date == nil {
-		dateEnded = "running"
+		dateEnded = "running" // nolint: goconst
 	} else {
 		dateEnded = data.DateEnded.Date.String()
 	}

--- a/cmd/rundeck/cmds/root.go
+++ b/cmd/rundeck/cmds/root.go
@@ -15,6 +15,7 @@ func RootCommand() {
 		Short: "Unified rundeck cli binary",
 	}
 	cmd.AddCommand(projectCommands(),
+		adHocCommands(),
 		listCommands(),
 		systemPoliciesCommands(),
 		jobCommands(),

--- a/cmd/rundeck/cmds/run_adhoc_command.go
+++ b/cmd/rundeck/cmds/run_adhoc_command.go
@@ -1,0 +1,75 @@
+package cmds
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lusis/go-rundeck/pkg/cli"
+	rundeck "github.com/lusis/go-rundeck/pkg/rundeck"
+	"github.com/spf13/cobra"
+)
+
+func runAdHocCmdFunc(cmd *cobra.Command, args []string) error {
+	projectID := args[0]
+	command := args[1:]
+	options := []rundeck.AdHocRunOption{
+		rundeck.CmdThreadCount(adHocNodeThreadCount),
+		rundeck.CmdKeepGoing(adHocNodeKeepGoing),
+	}
+	if &adHocAsUser != nil {
+		options = append(options, rundeck.CmdRunAs(adHocAsUser))
+	}
+	if &adHocFilter != nil {
+		options = append(options, rundeck.CmdNodeFilters(adHocFilter)) // nolint: ineffassign
+	}
+	res, err := cli.Client.RunAdHocCommand(projectID, strings.Join(command, " "), options...)
+	if err != nil {
+		return err
+	}
+	data, dataErr := cli.Client.GetExecutionInfo(fmt.Sprintf("%d", res.Execution.ID))
+	if dataErr != nil {
+		return fmt.Errorf("Execution started but unable to get information: %s", dataErr.Error())
+	}
+	cli.OutputFormatter.SetHeaders([]string{
+		"ID",
+		"User",
+		"Status",
+		"Start Date",
+		"End Date",
+		"Args",
+		"Server UUID",
+		"Custom Status",
+	})
+	var dateEnded string
+	if data.DateEnded.Date == nil {
+		dateEnded = ""
+	} else {
+		dateEnded = data.DateEnded.Date.String()
+	}
+	if rowErr := cli.OutputFormatter.AddRow([]string{
+		fmt.Sprintf("%d", data.ID),
+		data.User,
+		data.Status,
+		data.DateStarted.Date.String(),
+		dateEnded,
+		data.ArgString,
+		data.ServerUUID,
+		data.CustomStatus,
+	}); rowErr != nil {
+		return rowErr
+	}
+
+	cli.OutputFormatter.Draw()
+	return nil
+}
+
+func runAdHocCmdCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run project-name command",
+		Short: "runs the specified command against a project on the rundeck server. Consider quoting command",
+		Args:  cobra.MinimumNArgs(2),
+		RunE:  runAdHocCmdFunc,
+	}
+	rootCmd := cli.New(cmd)
+	return rootCmd
+}

--- a/cmd/rundeck/cmds/run_adhoc_script.go
+++ b/cmd/rundeck/cmds/run_adhoc_script.go
@@ -1,0 +1,91 @@
+package cmds
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lusis/go-rundeck/pkg/cli"
+	rundeck "github.com/lusis/go-rundeck/pkg/rundeck"
+	"github.com/spf13/cobra"
+)
+
+func runAdHocScriptFunc(cmd *cobra.Command, args []string) error {
+	projectID := args[0]
+	script := args[1]
+	options := []rundeck.AdHocScriptOption{
+		rundeck.ScriptThreadCount(adHocNodeThreadCount),
+		rundeck.ScriptKeepGoing(adHocNodeKeepGoing),
+		rundeck.ScriptArgsQuoted(adHocArgsQuoted),
+		rundeck.ScriptInterpreter(adHocScriptInterpreter),
+	}
+	if &adHocAsUser != nil {
+		options = append(options, rundeck.ScriptRunAs(adHocAsUser))
+	}
+	if &adHocArgString != nil {
+		options = append(options, rundeck.ScriptArgString(adHocArgString))
+	}
+	if &adHocFileExtension != nil {
+		options = append(options, rundeck.ScriptFileExtension(adHocFileExtension))
+	}
+	if &adHocFilter != nil {
+		options = append(options, rundeck.ScriptNodeFilters(adHocFilter)) // nolint: ineffassign
+	}
+	scriptData, scriptErr := os.Open(script)
+	if scriptErr != nil {
+		return scriptErr
+	}
+	res, err := cli.Client.RunAdHocScript(projectID, scriptData, options...)
+	if err != nil {
+		return err
+	}
+	data, dataErr := cli.Client.GetExecutionInfo(fmt.Sprintf("%d", res.Execution.ID))
+	if dataErr != nil {
+		return fmt.Errorf("Execution started but unable to get information: %s", dataErr.Error())
+	}
+	cli.OutputFormatter.SetHeaders([]string{
+		"ID",
+		"User",
+		"Status",
+		"Start Date",
+		"End Date",
+		"Args",
+		"Server UUID",
+		"Custom Status",
+	})
+	var dateEnded string
+	if data.DateEnded.Date == nil {
+		dateEnded = "running"
+	} else {
+		dateEnded = data.DateEnded.Date.String()
+	}
+	if rowErr := cli.OutputFormatter.AddRow([]string{
+		fmt.Sprintf("%d", data.ID),
+		data.User,
+		data.Status,
+		data.DateStarted.Date.String(),
+		dateEnded,
+		data.ArgString,
+		data.ServerUUID,
+		data.CustomStatus,
+	}); rowErr != nil {
+		return rowErr
+	}
+
+	cli.OutputFormatter.Draw()
+	return nil
+}
+
+func runAdHocScriptCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "script project-name script-file",
+		Short: "uploads the specified script and runs it against a project on the rundeck server",
+		Args:  cobra.MinimumNArgs(2),
+		RunE:  runAdHocScriptFunc,
+	}
+	rootCmd := cli.New(cmd)
+	rootCmd.Flags().StringVar(&adHocScriptInterpreter, "interpreter", "/bin/bash", "the script interpreter to use")
+	rootCmd.Flags().StringVar(&adHocFileExtension, "file-extension", "", "file extension to use on the remote node")
+	rootCmd.Flags().StringVar(&adHocArgString, "argstring", "", "args string to pass to the script")
+	rootCmd.Flags().BoolVar(&adHocArgsQuoted, "args-quoted", false, "should arguments to interpreter be quoted")
+	return rootCmd
+}

--- a/cmd/rundeck/cmds/run_adhoc_url.go
+++ b/cmd/rundeck/cmds/run_adhoc_url.go
@@ -2,39 +2,35 @@ package cmds
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/lusis/go-rundeck/pkg/cli"
 	rundeck "github.com/lusis/go-rundeck/pkg/rundeck"
 	"github.com/spf13/cobra"
 )
 
-func runAdHocScriptFunc(cmd *cobra.Command, args []string) error {
+func runAdHocURLFunc(cmd *cobra.Command, args []string) error {
 	projectID := args[0]
 	script := args[1]
-	options := []rundeck.AdHocScriptOption{
-		rundeck.ScriptThreadCount(adHocNodeThreadCount),
-		rundeck.ScriptKeepGoing(adHocNodeKeepGoing),
-		rundeck.ScriptArgsQuoted(adHocArgsQuoted),
-		rundeck.ScriptInterpreter(adHocScriptInterpreter),
+	options := []rundeck.AdHocScriptURLOption{
+		rundeck.ScriptURLThreadCount(adHocNodeThreadCount),
+		rundeck.ScriptURLKeepGoing(adHocNodeKeepGoing),
+		rundeck.ScriptURLArgsQuoted(adHocArgsQuoted),
+		rundeck.ScriptURLInterpreter(adHocScriptInterpreter),
 	}
 	if &adHocAsUser != nil {
-		options = append(options, rundeck.ScriptRunAs(adHocAsUser))
+		options = append(options, rundeck.ScriptURLRunAs(adHocAsUser))
 	}
 	if &adHocArgString != nil {
-		options = append(options, rundeck.ScriptArgString(adHocArgString))
+		options = append(options, rundeck.ScriptURLArgString(adHocArgString))
 	}
 	if &adHocFileExtension != nil {
-		options = append(options, rundeck.ScriptFileExtension(adHocFileExtension))
+		options = append(options, rundeck.ScriptURLFileExtension(adHocFileExtension))
 	}
 	if &adHocFilter != nil {
-		options = append(options, rundeck.ScriptNodeFilters(adHocFilter)) // nolint: ineffassign
+		options = append(options, rundeck.ScriptURLNodeFilters(adHocFilter)) // nolint: ineffassign
 	}
-	scriptData, scriptErr := os.Open(script)
-	if scriptErr != nil {
-		return scriptErr
-	}
-	res, err := cli.Client.RunAdHocScript(projectID, scriptData, options...)
+
+	res, err := cli.Client.RunAdHocScriptFromURL(projectID, script, options...)
 	if err != nil {
 		return err
 	}
@@ -75,12 +71,12 @@ func runAdHocScriptFunc(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runAdHocScriptCommand() *cobra.Command {
+func runAdHocURLCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "script project-name script-file",
-		Short: "uploads the specified script and runs it against a project on the rundeck server",
+		Use:   "url project-name script-url",
+		Short: "runs script at specified url against a project on the rundeck server",
 		Args:  cobra.MinimumNArgs(2),
-		RunE:  runAdHocScriptFunc,
+		RunE:  runAdHocURLFunc,
 	}
 	rootCmd := cli.New(cmd)
 	rootCmd.Flags().StringVar(&adHocScriptInterpreter, "interpreter", "/bin/bash", "the script interpreter to use")

--- a/pkg/rundeck/adhoc.go
+++ b/pkg/rundeck/adhoc.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 
 	multierror "github.com/hashicorp/go-multierror"
 	requests "github.com/lusis/go-rundeck/pkg/rundeck/requests"
@@ -41,9 +43,9 @@ func CmdThreadCount(count int) AdHocRunOption {
 }
 
 // CmdKeepGoing is the option to keep running even if a node fails
-func CmdKeepGoing() AdHocRunOption {
+func CmdKeepGoing(b bool) AdHocRunOption {
 	return func(c *requests.AdHocCommandRequest) error {
-		c.NodeKeepGoing = true
+		c.NodeKeepGoing = b
 		return nil
 	}
 }
@@ -77,18 +79,180 @@ func (c *Client) RunAdHocCommand(projectID string, exec string, opts ...AdHocRun
 	return data, nil
 }
 
-// RunAdHocScript runs a script ad-hoc
-// http://rundeck.org/docs/api/index.html#running-adhoc-scripts
-func (c *Client) RunAdHocScript() error {
-	if err := c.checkRequiredAPIVersion(responses.AdHocExecutionResponse{}); err != nil {
-		return err
+// AdHocScriptOption is a function option type for adhoc commands
+type AdHocScriptOption func(c *map[string]string) error
+
+// ScriptRunAs is the option for specifying who to run an adhoc command
+func ScriptRunAs(user string) AdHocScriptOption {
+	return func(c *map[string]string) error {
+		(*c)["asUser"] = user
+		return nil
 	}
-	return fmt.Errorf("not yet implemented")
 }
 
-// RunAdHocScriptFromURL runs a script ad-hoc from a url
-// http://rundeck.org/docs/api/index.html#running-adhoc-script-urls
-func (c *Client) RunAdHocScriptFromURL() error {
+// ScriptNodeFilters is the option for passing node filters to an adhoc command
+func ScriptNodeFilters(filters string) AdHocScriptOption {
+	return func(c *map[string]string) error {
+		(*c)["filter"] = filters
+		return nil
+	}
+}
+
+// ScriptThreadCount is the option for number of threads to run an adhoc command
+func ScriptThreadCount(count int) AdHocScriptOption {
+	return func(c *map[string]string) error {
+		(*c)["nodeThreadcount"] = fmt.Sprintf("%d", count)
+		return nil
+	}
+}
+
+// ScriptKeepGoing is the option to keep running even if a node fails
+func ScriptKeepGoing(b bool) AdHocScriptOption {
+	return func(c *map[string]string) error {
+		(*c)["nodeKeepgoing"] = fmt.Sprintf("%t", b)
+		return nil
+	}
+
+}
+
+// ScriptInterpreter is the option to set the Script interpreter
+func ScriptInterpreter(i string) AdHocScriptOption {
+	return func(c *map[string]string) error {
+		(*c)["scriptInterpreter"] = i
+		return nil
+	}
+}
+
+// ScriptArgString is the option for setting arguments passed to the Script being run
+func ScriptArgString(i string) AdHocScriptOption {
+	return func(c *map[string]string) error {
+		(*c)["argString"] = i
+		return nil
+	}
+}
+
+// ScriptArgsQuoted is the option for setting if Script and args are quoted when passed to the interpreter
+func ScriptArgsQuoted(q bool) AdHocScriptOption {
+	return func(c *map[string]string) error {
+		(*c)["interpreterArgsQuoted"] = fmt.Sprintf("%t", q)
+		return nil
+	}
+}
+
+// ScriptFileExtension is the option for setting the file extension on the remote host
+func ScriptFileExtension(e string) AdHocScriptOption {
+	return func(c *map[string]string) error {
+		(*c)["fileExtension"] = e
+		return nil
+	}
+}
+
+// RunAdHocScript runs a Script ad-hoc
+// http://rundeck.org/docs/api/index.html#running-adhoc-scripts
+func (c *Client) RunAdHocScript(projectID string, scriptData io.Reader, opts ...AdHocScriptOption) (*AdHocExecution, error) {
+	if err := c.checkRequiredAPIVersion(responses.AdHocExecutionResponse{}); err != nil {
+		return nil, err
+	}
+	data := &AdHocExecution{}
+	qp := &map[string]string{}
+	for _, opt := range opts {
+		if err := opt(qp); err != nil {
+			return nil, &OptionError{msg: multierror.Append(errOption, err).Error()}
+		}
+	}
+
+	scriptBytes, sbErr := ioutil.ReadAll(scriptData)
+	if sbErr != nil {
+		return nil, sbErr
+	}
+	if (*qp)["filter"] == "" {
+		(*qp)["filter"] = "name: .*"
+	}
+	(*qp)["scriptFile"] = string(scriptBytes)
+	res, err := c.httpPost("project/"+projectID+"/run/script",
+		requestExpects(200),
+		accept("application/json"),
+		contentType("application/x-www-form-urlencoded"),
+		queryParams(*qp))
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(res, data); err != nil {
+		return nil, &UnmarshalError{msg: multierror.Append(errEncoding, err).Error()}
+	}
+	return data, nil
+}
+
+// AdHocScriptURLOption is a function option type for adhoc commands
+type AdHocScriptURLOption func(c *requests.AdHocScriptURLRequest) error
+
+// ScriptURLRunAs is the option for specifying who to run an adhoc command
+func ScriptURLRunAs(user string) AdHocScriptURLOption {
+	return func(c *requests.AdHocScriptURLRequest) error {
+		c.AsUser = user
+		return nil
+	}
+}
+
+// ScriptURLNodeFilters is the option for passing node filters to an adhoc command
+func ScriptURLNodeFilters(filters string) AdHocScriptURLOption {
+	return func(c *requests.AdHocScriptURLRequest) error {
+		c.Filter = filters
+		return nil
+	}
+}
+
+// ScriptURLThreadCount is the option for number of threads to run an adhoc command
+func ScriptURLThreadCount(count int) AdHocScriptURLOption {
+	return func(c *requests.AdHocScriptURLRequest) error {
+		c.NodeThreadCount = count
+		return nil
+	}
+}
+
+// ScriptURLKeepGoing is the option to keep running even if a node fails
+func ScriptURLKeepGoing() AdHocScriptURLOption {
+	return func(c *requests.AdHocScriptURLRequest) error {
+		c.NodeKeepGoing = true
+		return nil
+	}
+}
+
+// ScriptURLInterpreter is the option to set the ScriptURL interpreter
+func ScriptURLInterpreter(i string) AdHocScriptURLOption {
+	return func(c *requests.AdHocScriptURLRequest) error {
+		c.ScriptInterpreter = i
+		return nil
+	}
+}
+
+// ScriptURLArgString is the option for setting arguments passed to the ScriptURL being run
+func ScriptURLArgString(i string) AdHocScriptURLOption {
+	return func(c *requests.AdHocScriptURLRequest) error {
+		c.ArgString = i
+		return nil
+	}
+}
+
+// ScriptURLArgsQuoted is the option for setting if ScriptURL and args are quoted when passed to the interpreter
+func ScriptURLArgsQuoted(q bool) AdHocScriptURLOption {
+	return func(c *requests.AdHocScriptURLRequest) error {
+		c.InterpreterArgsQuoted = q
+		return nil
+	}
+}
+
+// ScriptURLFileExtension is the option for setting the file extension on the remote host
+func ScriptURLFileExtension(e string) AdHocScriptURLOption {
+	return func(c *requests.AdHocScriptURLRequest) error {
+		c.FileExtension = e
+		return nil
+	}
+}
+
+// RunAdHocScriptURLFromURL runs a ScriptURL ad-hoc from a url
+// http://rundeck.org/docs/api/index.html#running-adhoc-ScriptURL-urls
+func (c *Client) RunAdHocScriptURLFromURL() error {
 	if err := c.checkRequiredAPIVersion(responses.AdHocExecutionResponse{}); err != nil {
 		return err
 	}

--- a/pkg/rundeck/adhoc_test.go
+++ b/pkg/rundeck/adhoc_test.go
@@ -2,6 +2,7 @@ package rundeck
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	requests "github.com/lusis/go-rundeck/pkg/rundeck/requests"
@@ -101,4 +102,44 @@ func TestRunAdHocHTTPError(t *testing.T) {
 	res, resErr := client.RunAdHocCommand("testproject", "ps -ef")
 	assert.Error(t, resErr)
 	assert.Nil(t, res)
+}
+
+func TestRunAdHocScript(t *testing.T) {
+	jsonfile, err := testdata.GetBytes(responses.AdHocExecutionResponseTestFile)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	client, server, cErr := newTestRundeckClient(jsonfile, "application/json", 200)
+	defer server.Close()
+	if cErr != nil {
+		t.Fatalf(cErr.Error())
+	}
+	res, resErr := client.RunAdHocScript("testproject", strings.NewReader("ps -ef"))
+	assert.NoError(t, resErr)
+	assert.NotNil(t, res)
+	assert.Equal(t, "Immediate execution scheduled (X)", res.Message)
+	assert.Equal(t, 1, res.Execution.ID)
+	assert.Equal(t, "[API Href]", res.Execution.HRef)
+	assert.Equal(t, "[GUI Href]", res.Execution.Permalink)
+}
+
+func TestRunAdHocScriptURL(t *testing.T) {
+	jsonfile, err := testdata.GetBytes(responses.AdHocExecutionResponseTestFile)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	client, server, cErr := newTestRundeckClient(jsonfile, "application/json", 200)
+	defer server.Close()
+	if cErr != nil {
+		t.Fatalf(cErr.Error())
+	}
+	res, resErr := client.RunAdHocScriptFromURL("testproject", "http://localhost/script.sh")
+	assert.NoError(t, resErr)
+	assert.NotNil(t, res)
+	assert.Equal(t, "Immediate execution scheduled (X)", res.Message)
+	assert.Equal(t, 1, res.Execution.ID)
+	assert.Equal(t, "[API Href]", res.Execution.HRef)
+	assert.Equal(t, "[GUI Href]", res.Execution.Permalink)
 }

--- a/pkg/rundeck/adhoc_test.go
+++ b/pkg/rundeck/adhoc_test.go
@@ -52,7 +52,7 @@ func TestRunAdHocWithOptions(t *testing.T) {
 		CmdRunAs("auser"),
 		CmdNodeFilters("*"),
 		CmdThreadCount(2),
-		CmdKeepGoing(),
+		CmdKeepGoing(true),
 	}
 	res, resErr := client.RunAdHocCommand("testproject", "ps -ef", options...)
 	assert.NoError(t, resErr)

--- a/pkg/rundeck/constants.go
+++ b/pkg/rundeck/constants.go
@@ -2,6 +2,9 @@ package rundeck
 
 import "errors"
 
+// defaultNodeFilter is the default filter to use when things require a node filter string
+const defaultNodeFilter = "name: .*"
+
 // MaxRundeckVersion is the maximum version of the api this library supports
 // can be overridden
 // TODO: make this a min/max option and validate

--- a/pkg/rundeck/requests/adhoc.go
+++ b/pkg/rundeck/requests/adhoc.go
@@ -1,6 +1,16 @@
 package requests
 
+// AdHocCommonRequest represents fields that are common in all adhoc requests
+type AdHocCommonRequest struct {
+	Project         string `json:"project"`
+	NodeThreadCount int    `json:"nodeThreadcount,omitempty"`
+	NodeKeepGoing   bool   `json:"nodeKeepgoing,omitempty"`
+	AsUser          string `json:"asUser,omitempty"`
+	Filter          string `json:"filter,omitempty"`
+}
+
 // AdHocCommandRequest represents an AdHocCommand request
+// http://rundeck.org/docs/api/index.html#running-adhoc-commands
 /*
 {
     "project":"[project]",
@@ -12,10 +22,56 @@ package requests
 }
 */
 type AdHocCommandRequest struct {
-	Project         string `json:"project"`
-	Exec            string `json:"exec"`
-	NodeThreadCount int    `json:"nodeThreadcount,omitempty"`
-	NodeKeepGoing   bool   `json:"nodeKeepGoing,omitempty"`
-	AsUser          string `json:"asUser,omitempty"`
-	Filter          string `json:"filter,omitempty"`
+	Exec string `json:"exec"`
+	AdHocCommonRequest
+}
+
+// AdHocScriptRequest represents an AdHocScript request
+// http://rundeck.org/docs/api/index.html#running-adhoc-scripts
+/*
+{
+    "project":"[project]",
+    "script":"[script]",
+    "nodeThreadcount": #threadcount#,
+    "nodeKeepgoing": true/false,
+    "asUser": "[asUser]",
+    "argString": "[argString]",
+    "scriptInterpreter": "[scriptInterpreter]",
+    "interpreterArgsQuoted": true/false,
+    "fileExtension": "[fileExtension]",
+    "filter": "[node filter string]"
+}
+*/
+type AdHocScriptRequest struct {
+	Script                string `json:"script"`
+	ArgString             string `json:"argString,omitempty"`
+	ScriptInterpreter     string `json:"scriptInterpreter,omitempty"`
+	InterpreterArgsQuoted bool   `json:"interpreterArgsQuoted, omitempty"`
+	FileExtension         string `json:"fileExtension,omitempty"`
+	AdHocCommonRequest
+}
+
+// AdHocScriptURLRequest represents an adhoc script request
+// http://rundeck.org/docs/api/index.html#running-adhoc-script-urls
+/*
+{
+    "project":"[project]",
+    "url":"[scriptURL]",
+    "nodeThreadcount": #threadcount#,
+    "nodeKeepgoing": true/false,
+    "asUser": "[asUser]",
+    "argString": "[argString]",
+    "scriptInterpreter": "[scriptInterpreter]",
+    "interpreterArgsQuoted": true/false,
+    "fileExtension": "[fileExtension]",
+    "filter": "[node filter string]"
+}
+*/
+type AdHocScriptURLRequest struct {
+	URL                   string `json:"url"`
+	ArgString             string `json:"argString,omitempty"`
+	ScriptInterpreter     string `json:"scriptInterpreter,omitempty"`
+	InterpreterArgsQuoted bool   `json:"interpreterArgsQuoted, omitempty"`
+	FileExtension         string `json:"fileExtension,omitempty"`
+	AdHocCommonRequest
 }


### PR DESCRIPTION
This adds full support for adhoc exection via all three mechanisms:
- command string
- script file
- script file url

While the request json for each of these is stubbed out, we only use json post body for commands.

Functionality has been added to the `rundeck` binary as:
- `rundeck adhoc run <projectname> <command>`
- `rundeck adhoc script <projectname> <filename>`
- `rundeck adhoc url <projectname> <script url>`

With all three commands there are persistent flags inherited from `rundeck adhoc`:

```
      --as-user string     rundeck user to run as
      --filter string      rundeck filter to use
      --keep-going         keep going on failure
      --thread-count int   node thread count (default 1)
```

as these are common across all three.

The script options have the following additonal flags:

```
      --args-quoted             should arguments to interpreter be quoted
      --argstring string        args string to pass to the script
      --file-extension string   file extension to use on the remote node
      --interpreter string      the script interpreter to use (default "/bin/bash")
```

There are two scripts as public gists [here](https://gist.github.com/lusis/c230f2d8323e0d440a29d25a8b3bb7af) that I've used with the binary.

They can also be used later when integration testing is finally a thing.

With script files, it's safer and cleaner to use multipart form.
With both script files and script urls, we still had to pass some things as query params which seemed foolish if everything was in the json body so we just did everything as query params.

The test cases for error handling in `RunAdHocScriptFromURL` and `RunAdHocScript` are not fully done but happy path *IS* tested.
  