### PR TITLE
v27 support

### DIFF
--- a/pkg/rundeck/constants.go
+++ b/pkg/rundeck/constants.go
@@ -8,7 +8,7 @@ const defaultNodeFilter = "name: .*"
 // MaxRundeckVersion is the maximum version of the api this library supports
 // can be overridden
 // TODO: make this a min/max option and validate
-const MaxRundeckVersion = "21"
+const MaxRundeckVersion = "27"
 
 // minimum version of rundeck api version that supports json
 const minJSONSupportedAPIVersion = 14

--- a/pkg/rundeck/responses/versioned_response.go
+++ b/pkg/rundeck/responses/versioned_response.go
@@ -12,7 +12,7 @@ type VersionedResponse interface {
 const AbsoluteMinimumVersion = 14
 
 // CurrentVersion is the current version of the API that this library is tested against
-const CurrentVersion = 21
+const CurrentVersion = 27
 
 // GetMinVersionFor gets the minimum api version required for a response
 func GetMinVersionFor(a VersionedResponse) int { return a.minVersion() }


### PR DESCRIPTION
- upgraded integration container to 3.0.9
- bumped supported api version to 27 and tested