### PR TITLE
Use custom cookiejar to prevent JSESSIONID errors

### DIFF
--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -24,7 +24,7 @@ type Response struct {
 // Request represents an http request
 type Request struct {
 	httpClient         *http.Client
-	cookieJar          *cookiejar.Jar
+	cookieJar          http.CookieJar
 	url                string
 	method             string
 	contentType        string
@@ -80,7 +80,7 @@ func QueryParams(m map[string]string) RequestOption {
 }
 
 // SetCookieJar sets the cookie jar to be used with requests
-func SetCookieJar(jar *cookiejar.Jar) RequestOption {
+func SetCookieJar(jar http.CookieJar) RequestOption {
 	return func(r *Request) error {
 		r.cookieJar = jar
 		return nil

--- a/pkg/rundeck/http.go
+++ b/pkg/rundeck/http.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"net/http/cookiejar"
 	"net/url"
 	"strings"
 
@@ -182,13 +181,13 @@ func (rc *Client) authWrap() ([]httpclient.RequestOption, error) {
 			httpclient.AddHeaders(map[string]string{
 				"User-Agent": "rundeck-go.v" + rc.Config.APIVersion,
 			}),
-			httpclient.SetCookieJar(rc.HTTPClient.Jar.(*cookiejar.Jar))}, authErr
+			httpclient.SetCookieJar(rc.HTTPClient.Jar)}, authErr
 	}
 	headers := make(map[string]string, 2)
 	headers["X-Rundeck-Auth-Token"] = rc.Config.Token
 	headers["User-Agent"] = "rundeck-go.v" + rc.Config.APIVersion
-
 	return []httpclient.RequestOption{
+		httpclient.SetCookieJar(rc.HTTPClient.Jar),
 		httpclient.AddHeaders(headers),
 		httpclient.SetClient(rc.HTTPClient),
 	}, nil
@@ -218,7 +217,7 @@ func (rc *Client) basicAuth() error {
 		httpclient.Accept("*/*"),
 		httpclient.WithBody(authData),
 		httpclient.SetClient(rc.HTTPClient),
-		httpclient.SetCookieJar(rc.HTTPClient.Jar.(*cookiejar.Jar)),
+		httpclient.SetCookieJar(rc.HTTPClient.Jar),
 	}
 	authReq, authReqErr := httpclient.Post(authURL, opts...)
 	if authReqErr != nil {


### PR DESCRIPTION
Hi !

This PR fix rundeck's bug about `JSESSIONID`, currently rundeck doesn't allow api clients to get multiple sessions for the same user (but it should as mentionned in https://docs.rundeck.com/docs/administration/configuration/configuration-file-reference.html - see rundeck.security.maxSessions parameter).

When `AuthMethod` is "token", it inject `TokenAuthCookieJar` as `http.CookieJar `and then remove `JSESSIONID` cookies from request.

Same workaround has been implemented in official rundeck golang api (https://github.com/rundeck/go-rundeck/commit/38df8401023e7d1fa635d0eda9db6eca5d08ec8f)